### PR TITLE
Conformance checklist, hard violation scans, post-checkout and blueprint audit hooks

### DIFF
--- a/prompts/git-standards.md
+++ b/prompts/git-standards.md
@@ -126,16 +126,64 @@ GIT_BRAIN_METADATA:
 
 | Stage | Check | Behaviour |
 |---|---|---|
+| prepare-commit-msg | — | Injects conformance checklist into every new commit message |
 | pre-commit | Planning docs not staged | **BLOCKS** |
 | pre-commit | Commit touches > 10 files (excl. planning docs) | **Warns** — appended to next-prompt.md |
 | pre-commit | Lint / format | Auto-fixes applied; unfixable remainder **appended to next-prompt.md** |
+| commit-msg | Conformance checklist has unchecked boxes | **BLOCKS** |
 | commit-msg | GIT_BRAIN_METADATA missing or invalid | **BLOCKS** |
 | post-commit | Branch has ≥ 10 files changed vs. main | **Warns** — PR due; appended to next-prompt.md |
+| post-checkout | Branch switch | Refreshes `docs/standards/` via bootstrap script |
+| pre-push | Blueprint violations (.js files, forbidden packages) | **BLOCKS** |
 | pre-push | PR changes > 20 files vs. main | **BLOCKS** — split the PR |
 | pre-push | Lint / format / type failures | **BLOCKS** |
 | pre-push | Test suite failures | **Allows push** — appends failing tests to next-prompt.md |
 
 ---
+
+### Conformance Checklist Injection (`prepare-commit-msg`)
+
+The `prepare-commit-msg` hook fires before the agent writes the commit message. It appends a conformance checklist as an HTML comment — invisible in `git log` but present in the message buffer the agent edits. The agent must check every applicable box. The `commit-msg` hook then validates that no box is left unchecked, blocking the commit if any remain.
+
+This is a deterministic self-audit: the agent cannot commit without explicitly confirming alignment with Calypso's core rules on every single commit.
+
+**`scripts/hooks/prepare-commit-msg`:**
+
+```bash
+#!/usr/bin/env bash
+# prepare-commit-msg: Injects Calypso conformance checklist into every new commit message.
+
+COMMIT_FILE="$1"
+COMMIT_SOURCE="$2"
+
+# Only inject on fresh commits — skip merges, squashes, amends, fixups
+case "$COMMIT_SOURCE" in
+  merge|squash|commit|fixup) exit 0 ;;
+esac
+
+grep -q "CALYPSO_CHECKLIST" "$COMMIT_FILE" && exit 0
+
+cat >> "$COMMIT_FILE" <<'EOF'
+
+<!--
+CALYPSO_CHECKLIST:
+Check every applicable box. The commit-msg hook blocks if any box remains unchecked.
+
+- [ ] TypeScript only — no .js or .mjs logic files added or modified
+- [ ] Bun only — no npm, npx, or yarn calls introduced anywhere
+- [ ] No mocks — no jest.mock, sinon, vi.mock, or msw on external dependencies
+- [ ] No forbidden libs — no ORM, Docker config, external auth provider, Redux/Zustand added
+- [ ] No skipped tests — no .skip(), .todo(), xit(), or commented-out test cases
+- [ ] implementation-plan.md — completed tasks checked off; new discoveries added
+- [ ] next-prompt.md — overwritten with the complete, self-contained prompt for the next commit
+- [ ] retroactive_prompt — written as a specific reproduction instruction, not a diff summary
+-->
+EOF
+```
+
+**Hard vs. soft split:** The `pre-commit` hook scans the staged diff deterministically for all automatable violations (JS files, npm/npx usage, mocks, skipped tests, forbidden packages). These fire before the message is written and require no agent input. The checklist injected by `prepare-commit-msg` covers only the three things the agent must self-verify: planning doc quality and metadata intent. This keeps the checklist minimal and meaningful — every item on it genuinely requires human or agent judgement.
+
+The checklist lives inside an HTML comment so it does not appear in `git log --oneline` or PR diffs, but is fully visible to the agent writing the message.
 
 ### Pre-commit Stage
 
@@ -249,9 +297,9 @@ fi
 exit 0
 ```
 
-### Metadata Enforcement Hook (blocking, `commit-msg`)
+### Metadata and Checklist Enforcement Hook (blocking, `commit-msg`)
 
-The `commit-msg` hook fires after the commit message is written and validates that `GIT_BRAIN_METADATA` is present and schema-valid. The commit is rejected if the block is missing, the JSON is malformed, or any required field is absent or empty.
+The `commit-msg` hook fires after the commit message is written and runs two validations in sequence: first the conformance checklist (any unchecked box blocks), then the `GIT_BRAIN_METADATA` schema (missing block, malformed JSON, or empty required fields block).
 
 This hook runs at a different stage than `pre-commit` — it receives the commit message file as its first argument and inspects its content.
 
@@ -399,7 +447,7 @@ exit 0
 
 ```bash
 mkdir -p .git/hooks
-for hook in pre-commit commit-msg post-commit pre-push; do
+for hook in prepare-commit-msg pre-commit commit-msg post-commit post-checkout pre-push; do
   cp scripts/hooks/$hook .git/hooks/$hook
   chmod +x .git/hooks/$hook
 done
@@ -407,9 +455,39 @@ done
 
 ---
 
+### Standards Refresh Hook (`post-checkout`)
+
+The `post-checkout` hook fires after every branch switch. It runs `bootstrap-standards.sh` to ensure `docs/standards/` is current with the latest Calypso templates. This prevents an agent resuming work on a stale branch from operating with outdated conventions.
+
+**`scripts/hooks/post-checkout`:**
+
+```bash
+#!/usr/bin/env bash
+# post-checkout: Refreshes Calypso standards after switching branches.
+
+PREV_HEAD="$1"; NEW_HEAD="$2"; BRANCH_CHECKOUT="$3"
+
+[ "$BRANCH_CHECKOUT" != "1" ] && exit 0
+[ "$PREV_HEAD" = "$NEW_HEAD" ] && exit 0
+
+echo "post-checkout: refreshing Calypso standards..." >&2
+
+if [ -f "./scripts/bootstrap-standards.sh" ]; then
+  bash ./scripts/bootstrap-standards.sh
+else
+  curl -sSL https://raw.githubusercontent.com/dot-matrix-labs/calypso/main/scripts/bootstrap-standards.sh | bash
+fi
+```
+
+---
+
 ### Pre-push Stage
 
-The pre-push hook runs two checks with different consequences.
+The pre-push hook runs four checks in order.
+
+**BLOCKS — Blueprint violations (architecture audit):**
+
+Before any quality checks, the hook scans the repository for hard architectural violations: JavaScript files in `apps/` or `packages/`, forbidden packages in `package.json`, and a missing `docs/standards/` directory. These are the antipatterns from `AGENT.md` enforced deterministically at push time — catching anything that slipped past the `pre-commit` staged-diff scan across the full working tree.
 
 **BLOCKS — Lint, format, and type errors:**
 

--- a/scripts/hooks/commit-msg
+++ b/scripts/hooks/commit-msg
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# commit-msg: Validates CALYPSO_CHECKLIST completion and GIT_BRAIN_METADATA schema.
+
+COMMIT_FILE="$1"
+MSG=$(cat "$COMMIT_FILE")
+
+# ── 1. Conformance Checklist ────────────────────────────────────────────────
+
+if echo "$MSG" | grep -q "CALYPSO_CHECKLIST:"; then
+  UNCHECKED=$(echo "$MSG" | grep -E "^\- \[ \]" || true)
+  if [ -n "$UNCHECKED" ]; then
+    echo "" >&2
+    echo "COMMIT BLOCKED: Conformance checklist has unchecked items:" >&2
+    echo "$UNCHECKED" >&2
+    echo "" >&2
+    echo "Check every applicable box in the CALYPSO_CHECKLIST before committing." >&2
+    echo "" >&2
+    exit 1
+  fi
+fi
+
+# ── 2. GIT_BRAIN_METADATA presence ─────────────────────────────────────────
+
+if ! echo "$MSG" | grep -q "GIT_BRAIN_METADATA:"; then
+  cat >&2 <<'BLOCK'
+
+COMMIT BLOCKED: GIT_BRAIN_METADATA block is missing from the commit message.
+
+Every agent commit must end with a metadata block. The key field is
+retroactive_prompt — not the instruction you were given, but the instruction
+you would write now, with full knowledge of what this change required, so that
+another agent could reproduce it without asking questions.
+
+Required format (append to the end of your commit message):
+
+<!--
+GIT_BRAIN_METADATA:
+{
+  "retroactive_prompt": "Specific, self-contained instruction to reproduce this change.",
+  "outcome": "Observable, verifiable result of this commit.",
+  "context": "Architectural or domain context not visible from the diff.",
+  "agent": "model-name",
+  "session": "session-id",
+  "hints": ["ordered", "implementation", "notes"]
+}
+-->
+
+BLOCK
+  exit 1
+fi
+
+# ── 3. GIT_BRAIN_METADATA schema ────────────────────────────────────────────
+
+JSON=$(echo "$MSG" | awk '/GIT_BRAIN_METADATA:/{found=1; next} found && /-->/{exit} found{print}')
+
+echo "$JSON" | bun run scripts/hooks/validate-commit-metadata.mjs >&2
+if [ $? -ne 0 ]; then
+  exit 1
+fi

--- a/scripts/hooks/post-checkout
+++ b/scripts/hooks/post-checkout
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# post-checkout: Refreshes Calypso standards whenever the agent switches branches.
+# Ensures docs/standards/ is always current with the latest templates.
+
+PREV_HEAD="$1"
+NEW_HEAD="$2"
+BRANCH_CHECKOUT="$3"
+
+# Only run on branch switches, not individual file checkouts
+[ "$BRANCH_CHECKOUT" != "1" ] && exit 0
+
+# Skip if HEAD didn't actually change (e.g. checkout of current branch)
+[ "$PREV_HEAD" = "$NEW_HEAD" ] && exit 0
+
+echo "post-checkout: refreshing Calypso standards..." >&2
+
+if [ -f "./scripts/bootstrap-standards.sh" ]; then
+  bash ./scripts/bootstrap-standards.sh
+else
+  curl -sSL https://raw.githubusercontent.com/dot-matrix-labs/calypso/main/scripts/bootstrap-standards.sh | bash
+fi

--- a/scripts/hooks/post-commit
+++ b/scripts/hooks/post-commit
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# post-commit: Warns when the branch has accumulated >= 10 file changes vs. main.
+# At that point a PR is due — annotates next-prompt.md and prints a console notice.
+
+PR_REMINDER_THRESHOLD=10
+
+MERGE_BASE=$(git merge-base HEAD origin/main 2>/dev/null \
+  || git merge-base HEAD main 2>/dev/null \
+  || echo "")
+
+[ -z "$MERGE_BASE" ] && exit 0
+
+BRANCH_FILE_COUNT=$(git diff --name-only "$MERGE_BASE" HEAD | wc -l | tr -d ' ')
+
+if [ "$BRANCH_FILE_COUNT" -ge "$PR_REMINDER_THRESHOLD" ]; then
+  echo "" >&2
+  echo "┌─────────────────────────────────────────────────────────┐" >&2
+  echo "│  PR DUE: ${BRANCH_FILE_COUNT} files changed on this branch vs. main.     │" >&2
+  echo "│  Open a pull request before this branch grows further.  │" >&2
+  echo "└─────────────────────────────────────────────────────────┘" >&2
+  echo "" >&2
+
+  cat >> docs/plans/next-prompt.md <<EOF
+
+---
+
+## PR Due — Open Before Continuing
+
+This branch has changed ${BRANCH_FILE_COUNT} files since main. A pull request must be opened
+imminently. Do this before starting the next feature task:
+
+1. Ensure lint and types are clean.
+2. Push the branch: \`git push\`
+3. Open a PR: \`gh pr create\`
+4. After merge, pull main and continue on a fresh or rebased branch.
+
+Do not accumulate further unreviewed changes on this branch.
+EOF
+fi
+
+exit 0

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# pre-commit: Hard violation scans (blocks) + planning gate (blocks) +
+#             commit size advisory + lint/format auto-fix.
+
+STAGED=$(git diff --cached --name-only)
+STAGED_DIFF=$(git diff --cached)
+
+# ── 1. Hard violation scans ─────────────────────────────────────────────────
+# These are deterministic checks on the staged diff — no agent assertion needed.
+
+VIOLATIONS=()
+
+# TypeScript only — no .js/.mjs logic files staged
+JS_STAGED=$(echo "$STAGED" | grep -E '\.(js|mjs)$' | grep -v '\.config\.' || true)
+[ -n "$JS_STAGED" ] && VIOLATIONS+=("JavaScript files staged (TypeScript only):\n${JS_STAGED}")
+
+# Bun only — no npm/npx/yarn introduced in staged changes
+NPM_USAGE=$(echo "$STAGED_DIFF" | grep "^+" | grep -v "^+++" \
+  | grep -E "(npm (install|run|exec|ci)|npx |yarn (add|run|install|exec))" || true)
+[ -n "$NPM_USAGE" ] && VIOLATIONS+=("npm/npx/yarn usage detected (use bun/bunx):\n${NPM_USAGE}")
+
+# No mocks — no mocking libraries introduced in staged changes
+MOCK_USAGE=$(echo "$STAGED_DIFF" | grep "^+" | grep -v "^+++" \
+  | grep -E "(jest\.mock\(|sinon\.|vi\.mock\(|msw)" || true)
+[ -n "$MOCK_USAGE" ] && VIOLATIONS+=("Mock usage detected (no mocking allowed):\n${MOCK_USAGE}")
+
+# No skipped tests — no .skip/.todo/xit introduced
+SKIPPED=$(echo "$STAGED_DIFF" | grep "^+" | grep -v "^+++" \
+  | grep -E "\.(skip|todo)\(|^xit\(|^xdescribe\(" || true)
+[ -n "$SKIPPED" ] && VIOLATIONS+=("Skipped/disabled tests detected:\n${SKIPPED}")
+
+# No forbidden packages added to package.json
+FORBIDDEN="\"redux\"|\"zustand\"|\"mobx\"|\"prisma\"|\"typeorm\"|\"drizzle-orm\"|\"@auth0/\"|\"@clerk/\"|\"mongoose\""
+PKG_ADDITIONS=$(echo "$STAGED_DIFF" | grep "^+" | grep -v "^+++" \
+  | grep -E "$FORBIDDEN" || true)
+[ -n "$PKG_ADDITIONS" ] && VIOLATIONS+=("Forbidden package added to package.json:\n${PKG_ADDITIONS}")
+
+if [ ${#VIOLATIONS[@]} -gt 0 ]; then
+  echo "" >&2
+  echo "COMMIT BLOCKED: Hard violations detected in staged changes:" >&2
+  for v in "${VIOLATIONS[@]}"; do
+    echo -e "\n  ✗ $v" >&2
+  done
+  echo "" >&2
+  exit 1
+fi
+
+# ── 2. Planning documents gate ──────────────────────────────────────────────
+
+PLAN_ERRORS=()
+
+if ! echo "$STAGED" | grep -q "^docs/plans/implementation-plan\.md$"; then
+  PLAN_ERRORS+=("docs/plans/implementation-plan.md")
+fi
+
+if ! echo "$STAGED" | grep -q "^docs/plans/next-prompt\.md$"; then
+  PLAN_ERRORS+=("docs/plans/next-prompt.md")
+fi
+
+if [ ${#PLAN_ERRORS[@]} -gt 0 ]; then
+  echo "" >&2
+  echo "COMMIT BLOCKED: The following planning files were not staged:" >&2
+  for f in "${PLAN_ERRORS[@]}"; do
+    echo "  - $f" >&2
+  done
+  echo "" >&2
+  echo "At every commit:" >&2
+  echo "  implementation-plan.md — check off completed tasks; add or reorder discovered tasks." >&2
+  echo "  next-prompt.md         — overwrite with the complete prompt for the next commit." >&2
+  echo "" >&2
+  exit 1
+fi
+
+# ── 3. Commit size advisory ─────────────────────────────────────────────────
+
+PLANNING_DOCS="docs/plans/implementation-plan.md
+docs/plans/next-prompt.md"
+STAGED_COUNT=$(echo "$STAGED" | grep -v "^$" | grep -vF "$PLANNING_DOCS" | wc -l | tr -d ' ')
+COMMIT_FILE_LIMIT=10
+
+if [ "$STAGED_COUNT" -gt "$COMMIT_FILE_LIMIT" ]; then
+  echo "" >&2
+  echo "COMMIT SIZE WARNING: This commit touches ${STAGED_COUNT} files (limit: ${COMMIT_FILE_LIMIT})." >&2
+  echo "Consider splitting this into smaller, more focused commits." >&2
+  echo "" >&2
+
+  cat >> docs/plans/next-prompt.md <<EOF
+
+---
+
+## Commit Size Warning
+
+The previous commit touched ${STAGED_COUNT} files (limit: ${COMMIT_FILE_LIMIT}).
+Commits should be small and focused. If the next task touches many files, split it.
+EOF
+fi
+
+# ── 4. Lint/format auto-fix + flag unfixable ────────────────────────────────
+
+bun run eslint . --fix 2>&1 || true
+bun run prettier --write . 2>&1 || true
+
+UNFIXED_ESLINT=$(bun run eslint . --max-warnings=0 2>&1) && ESLINT_CLEAN=1 || ESLINT_CLEAN=0
+UNFIXED_PRETTIER=$(bun run prettier --check . 2>&1) && PRETTIER_CLEAN=1 || PRETTIER_CLEAN=0
+
+if [ $ESLINT_CLEAN -eq 0 ] || [ $PRETTIER_CLEAN -eq 0 ]; then
+  echo "" >&2
+  echo "LINT/FORMAT: auto-fix applied. The following could not be fixed automatically:" >&2
+  [ $ESLINT_CLEAN -eq 0 ] && echo "$UNFIXED_ESLINT" >&2
+  [ $PRETTIER_CLEAN -eq 0 ] && echo "$UNFIXED_PRETTIER" >&2
+  echo "" >&2
+  echo "Commit allowed. These issues WILL block your next push." >&2
+  echo "They have been appended to next-prompt.md." >&2
+
+  cat >> docs/plans/next-prompt.md <<EOF
+
+---
+
+## Unfixed Lint/Format Issues — Must resolve before next push
+
+$([ $ESLINT_CLEAN -eq 0 ] && echo "### ESLint\n\`\`\`\n${UNFIXED_ESLINT}\n\`\`\`")
+$([ $PRETTIER_CLEAN -eq 0 ] && echo "### Prettier\n\`\`\`\n${UNFIXED_PRETTIER}\n\`\`\`")
+EOF
+fi
+
+exit 0

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# pre-push: Blueprint audit (blocks) + lint/format/type (blocks) + test suite (annotates).
+
+set -euo pipefail
+
+# ── 1. Blueprint audit — architectural violations ───────────────────────────
+
+echo "pre-push: running blueprint audit..." >&2
+
+VIOLATIONS=()
+
+# TypeScript only — no .js/.mjs logic files in apps/ or packages/
+JS_FILES=$(find apps packages -type f \( -name "*.js" -o -name "*.mjs" \) \
+  ! -path "*/node_modules/*" ! -path "*/dist/*" ! -name "*.config.*" 2>/dev/null || true)
+[ -n "$JS_FILES" ] && VIOLATIONS+=("JavaScript files found (TypeScript only):\n${JS_FILES}")
+
+# Forbidden packages
+FORBIDDEN="redux|zustand|mobx|prisma|typeorm|drizzle-orm|@auth0/|@clerk/|mongoose|docker"
+PKG_HITS=$(find . -name "package.json" ! -path "*/node_modules/*" \
+  -exec grep -lE "$FORBIDDEN" {} \; 2>/dev/null || true)
+[ -n "$PKG_HITS" ] && VIOLATIONS+=("Forbidden packages detected in:\n${PKG_HITS}")
+
+# docs/standards/ must exist
+[ ! -d "docs/standards" ] && VIOLATIONS+=("docs/standards/ is missing — run bootstrap-standards.sh")
+
+if [ ${#VIOLATIONS[@]} -gt 0 ]; then
+  echo "" >&2
+  echo "PUSH BLOCKED: Blueprint violations detected:" >&2
+  for v in "${VIOLATIONS[@]}"; do
+    echo -e "\n  ✗ $v" >&2
+  done
+  echo "" >&2
+  exit 1
+fi
+
+# ── 2. PR size gate ─────────────────────────────────────────────────────────
+
+PR_FILE_LIMIT=20
+MERGE_BASE=$(git merge-base HEAD origin/main 2>/dev/null \
+  || git merge-base HEAD main 2>/dev/null || echo "")
+
+if [ -n "$MERGE_BASE" ]; then
+  PR_FILE_COUNT=$(git diff --name-only "$MERGE_BASE"...HEAD | wc -l | tr -d ' ')
+  if [ "$PR_FILE_COUNT" -gt "$PR_FILE_LIMIT" ]; then
+    echo "" >&2
+    echo "PUSH BLOCKED: This PR changes ${PR_FILE_COUNT} files (limit: ${PR_FILE_LIMIT})." >&2
+    echo "" >&2
+    echo "Pull requests must be small and reviewable. Split this branch into smaller PRs:" >&2
+    echo "  1. Identify a logical subset of changes that can stand alone." >&2
+    echo "  2. Create a new branch from main with only those changes." >&2
+    echo "  3. Open a PR for that subset, get it merged." >&2
+    echo "  4. Repeat for the remaining changes." >&2
+    echo "" >&2
+    exit 1
+  fi
+fi
+
+# ── 3. Lint, format, and types ───────────────────────────────────────────────
+
+echo "pre-push: checking lint, format, and types..." >&2
+
+QUALITY_FAILED=0
+QUALITY_OUTPUT=""
+
+ESLINT_OUT=$(bun run eslint . --max-warnings=0 2>&1) || { QUALITY_FAILED=1; QUALITY_OUTPUT+="$ESLINT_OUT\n"; }
+PRETTIER_OUT=$(bun run prettier --check . 2>&1) || { QUALITY_FAILED=1; QUALITY_OUTPUT+="$PRETTIER_OUT\n"; }
+TSC_OUT=$(bun run tsc --noEmit 2>&1) || { QUALITY_FAILED=1; QUALITY_OUTPUT+="$TSC_OUT\n"; }
+
+if [ $QUALITY_FAILED -ne 0 ]; then
+  echo "" >&2
+  echo "PUSH BLOCKED: Lint, format, or type errors must be resolved before pushing." >&2
+  echo -e "$QUALITY_OUTPUT" >&2
+  echo "These were warned about at commit time. Fix them, update next-prompt.md, and commit." >&2
+  echo "" >&2
+  exit 1
+fi
+
+# ── 4. Full test suite ───────────────────────────────────────────────────────
+
+echo "pre-push: running full test suite..." >&2
+
+TEST_OUTPUT=$(bun test 2>&1) && TEST_EXIT=0 || TEST_EXIT=$?
+
+if [ $TEST_EXIT -ne 0 ]; then
+  FAILING=$(echo "$TEST_OUTPUT" | grep -E "^\s*(FAIL|✗|×|●|not ok)" | head -30 || true)
+
+  cat >> docs/plans/next-prompt.md <<EOF
+
+---
+
+## FAILING TESTS — Must be addressed before next push
+
+The following tests were failing at the time of the last push.
+They must be **checked, fixed, or rewritten. Never ignore or skip them.**
+
+\`\`\`
+${FAILING}
+\`\`\`
+
+For each failure: determine whether the test is wrong (fix the test to match
+correct behaviour) or the implementation is wrong (fix the code). Do not
+disable, comment out, or add skip/todo markers to avoid addressing failures.
+
+EOF
+
+  echo "" >&2
+  echo "WARNING: Test failures detected. Push is proceeding, but" >&2
+  echo "docs/plans/next-prompt.md has been updated with the failing tests." >&2
+  echo "They must be resolved — not ignored — in the next commit." >&2
+  echo "" >&2
+fi
+
+exit 0

--- a/scripts/hooks/prepare-commit-msg
+++ b/scripts/hooks/prepare-commit-msg
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# prepare-commit-msg: Injects soft conformance assertions into every new commit message.
+# Hard violations (JS files, mocks, forbidden packages, skipped tests) are caught
+# deterministically by the pre-commit hook. This checklist covers the things only
+# the agent can verify: planning doc quality and metadata intent.
+
+COMMIT_FILE="$1"
+COMMIT_SOURCE="$2"
+
+# Only inject on fresh commits — skip merges, squashes, amends, fixups
+case "$COMMIT_SOURCE" in
+  merge|squash|commit|fixup) exit 0 ;;
+esac
+
+# Skip if checklist already present (prevent duplicates)
+grep -q "CALYPSO_CHECKLIST" "$COMMIT_FILE" && exit 0
+
+cat >> "$COMMIT_FILE" <<'EOF'
+
+<!--
+CALYPSO_CHECKLIST:
+Hard violations (JS files, mocks, forbidden packages, skipped tests) were already
+checked automatically by the pre-commit hook. Confirm the following — things only
+you can verify. The commit-msg hook blocks if any box remains unchecked.
+
+- [ ] implementation-plan.md — completed tasks are checked off; newly discovered tasks are added
+- [ ] next-prompt.md — overwritten with a complete, self-contained prompt for the next commit
+- [ ] retroactive_prompt — written as a specific instruction to reproduce this change, not a summary of what changed
+-->
+EOF

--- a/scripts/hooks/validate-commit-metadata.mjs
+++ b/scripts/hooks/validate-commit-metadata.mjs
@@ -1,0 +1,36 @@
+// Reads GIT_BRAIN_METADATA JSON from stdin and validates the schema.
+// Exits 1 with a descriptive error if validation fails.
+
+const REQUIRED = ["retroactive_prompt", "outcome", "context", "agent", "session"];
+
+const chunks = [];
+for await (const chunk of process.stdin) chunks.push(chunk);
+const raw = chunks.join("").trim();
+
+if (!raw) {
+  process.stderr.write("GIT_BRAIN_METADATA: JSON block is empty.\n");
+  process.exit(1);
+}
+
+let metadata;
+try {
+  metadata = JSON.parse(raw);
+} catch (e) {
+  process.stderr.write(`GIT_BRAIN_METADATA: JSON parse error — ${e.message}\n`);
+  process.stderr.write("Ensure the block is valid JSON with no trailing commas.\n");
+  process.exit(1);
+}
+
+const missing = REQUIRED.filter(f => !metadata[f] || String(metadata[f]).trim() === "");
+if (missing.length > 0) {
+  process.stderr.write(`GIT_BRAIN_METADATA: Missing or empty required fields: ${missing.join(", ")}\n`);
+  REQUIRED.forEach(f => process.stderr.write(`  - ${f}\n`));
+  process.exit(1);
+}
+
+const rp = metadata.retroactive_prompt.trim();
+if (rp.length < 50) {
+  process.stderr.write("GIT_BRAIN_METADATA: retroactive_prompt is too short (minimum 50 characters).\n");
+  process.stderr.write("It must be specific enough for another agent to reproduce this change.\n");
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

Ports and rewrites the strongest ideas from `feat/git-hooks` onto the current main:

- **`prepare-commit-msg`** — injects a 3-item soft conformance checklist into every new commit message as an HTML comment. The agent must check each box; `commit-msg` blocks if any remain unchecked.
- **`pre-commit` hard violation scans** — staged diff is scanned deterministically before the agent writes the commit message:
  - `.js`/`.mjs` logic files staged → blocks
  - `npm`/`npx`/`yarn` usage introduced → blocks
  - `jest.mock`, `sinon`, `vi.mock`, `msw` in staged code → blocks
  - `.skip()`, `.todo()`, `xit()` in staged tests → blocks
  - Forbidden packages (`redux`, `prisma`, `@auth0`, `@clerk`, etc.) added to `package.json` → blocks
- **`post-checkout`** — runs `bootstrap-standards.sh` on every branch switch to keep `docs/standards/` current.
- **`pre-push` blueprint audit** — full working tree scan for JS files in `apps/`/`packages/`, forbidden packages across all `package.json` files, and missing `docs/standards/`. Blocks the push.
- **Hard/soft split** — automatable violations are caught by hooks before the message is written. The checklist covers only the 3 things code cannot verify: planning doc quality and `retroactive_prompt` intent.
- All six hooks now exist as real script files in `scripts/hooks/`. `validate-commit-metadata.mjs` extracted alongside them.

## Test plan

- [ ] `prepare-commit-msg` injects checklist on `git commit`, not on `--amend` or merge commits
- [ ] `commit-msg` blocks when any checklist box is unchecked
- [ ] `pre-commit` blocks when a `.js` file is staged in `apps/` or `packages/`
- [ ] `pre-commit` blocks when `npm install` appears in a staged file
- [ ] `pre-commit` blocks when `jest.mock(` appears in a staged test file
- [ ] `pre-commit` blocks when `.skip(` appears in staged test code
- [ ] `pre-commit` blocks when `redux` is added to a staged `package.json`
- [ ] `post-checkout` runs bootstrap on branch switch, skips on file checkout
- [ ] `pre-push` blocks when `.js` files exist in `apps/` or `packages/`
- [ ] `pre-push` blocks when forbidden packages appear in any `package.json`
- [ ] Bootstrap command installs all six hooks correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)