### PR TITLE
add project-level Claude Code config to disable co-author attribution

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,3 @@
+{
+  "includeCoAuthoredBy": false
+}


### PR DESCRIPTION
## Summary
- Adds `.claude/settings.json` with `includeCoAuthoredBy: false`
- Prevents Claude from appending `Co-Authored-By` lines to commits
- Shared in the repo so all installations inherit the setting automatically

## Test plan
- [ ] Clone repo fresh, open with Claude Code, make a commit — verify no `Co-Authored-By: Claude` line appears