### PR TITLE
docs: Recommend distroless containers

### DIFF
--- a/prompts/blueprints/deployment-blueprint.md
+++ b/prompts/blueprints/deployment-blueprint.md
@@ -36,7 +36,7 @@ The cost of ignoring this blueprint is a system that works in development and fa
 
 ### Containers are the great unifier
 
-An application process that is started manually and dies when the session ends is not deployed — it is running. Deployment means the application is packaged as an immutable container image, deployed to an orchestrator, and restarted on crash. We exclusively use containerized services. For enterprise deployments, the most credible architecture is Kubernetes. By enforcing containers across all environments, we reduce the amount of code and tools we need to maintain for hybrid environments and create sane reproductions across dev, test, and prod.
+An application process that is started manually and dies when the session ends is not deployed — it is running. Deployment means the application is packaged as an immutable container image, deployed to an orchestrator, and restarted on crash. We exclusively use containerized services. For enterprise deployments, the most credible architecture is Kubernetes. By enforcing containers across all environments, we reduce the amount of code and tools we need to maintain for hybrid environments and create sane reproductions across dev, test, and prod. For production environments, these containers must be "distroless" — stripped of package managers, shells, and all OS-level tools not strictly required to run the application, drastically reducing the attack surface.
 
 ### No incremental hot-reloading dev servers
 
@@ -62,13 +62,13 @@ Environment variables containing secrets (API keys, database passwords, signing 
 
 ## Design Patterns
 
-### Pattern 1: Immutable Container Builds
+### Pattern 1: Immutable Distroless Container Builds
 
-**Problem:** Applications behave differently in development, test, and production environments due to host-level drift, installed dependencies, or missing system libraries.
+**Problem:** Applications behave differently in development, test, and production environments due to host-level drift, installed dependencies, or missing system libraries. Furthermore, standard container images contain shells and package managers that drastically expand the attack surface.
 
-**Solution:** Every deployment—including local development previews—starts by building an immutable container image. The container encapsulates the exact runtime, dependencies, and compiled application assets.
+**Solution:** Every deployment—including local development previews—starts by building an immutable container image. The container encapsulates the exact runtime, dependencies, and compiled application assets. For the final production artifact, we implement a multi-stage build that copies the compiled application into a "distroless" base image. This final image contains only the application and its runtime, omitting the shell and OS utilities entirely.
 
-**Trade-offs:** Building a container image for every local change is slower than a hot-reloading development server. This is a deliberate trade-off: human impatience is discarded in favor of perfect mechanical reproducibility for the agent.
+**Trade-offs:** Building a container image for every local change is slower than a hot-reloading development server, and debugging distroless images requires more structured logging since you cannot `exec` into a shell. This is a deliberate trade-off: human convenience is discarded in favor of perfect mechanical reproducibility and zero-trust security.
 
 ### Pattern 2: Dual-Log Architecture
 

--- a/prompts/implementation-ts/data-implementation.md
+++ b/prompts/implementation-ts/data-implementation.md
@@ -30,7 +30,7 @@ Docker Compose starts PostgreSQL and Vault. An `init.sql` script (run once on fi
 
 ```
 # docker-compose.yml (relevant services)
-# postgres: standard postgres image, port 5432
+# postgres: distroless postgres image (e.g., cgr.dev/chainguard/postgres), port 5432
 # vault: hashicorp/vault image in dev mode, port 8200
 ```
 

--- a/prompts/implementation-ts/deployment-implementation.md
+++ b/prompts/implementation-ts/deployment-implementation.md
@@ -7,10 +7,11 @@
 
 ## Container Packaging
 
-Applications are packaged as immutable Docker containers and deployed via Kubernetes:
+Applications are packaged as immutable Docker containers using a multi-stage approach, and deployed via Kubernetes. The final production image uses the `oven/bun:1-distroless` image to eliminate the shell, package manager, and minimize the attack surface:
 
 ```dockerfile
 # apps/server/Dockerfile
+# STAGE 1: The Builder
 FROM oven/bun:1 AS base
 WORKDIR /app
 COPY package.json bun.lockb ./
@@ -20,10 +21,13 @@ COPY . .
 # Build the app explicitly for exact reproducibility
 RUN bun build apps/server/index.ts --target bun --outfile dist/server.js
 
-# Production stage
+# STAGE 2: The Production Distroless Runner
 FROM oven/bun:1-distroless
 WORKDIR /app
+
+# Copy the compiled application code
 COPY --from=base /app/dist/server.js ./
+
 CMD ["bun", "run", "server.js"]
 ```
 


### PR DESCRIPTION
Update deployment and data blueprint/implementation docs to explicitly recommend minimal distroless container distributions like gcr.io/distroless, oven/bun:1-distroless, and cgr.dev/chainguard/postgres in production.