### PR TITLE
fix: bootstrap copies full prompts/ tree via sparse clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Agent, bootstrap a new Calypso project.
 First, run:
 curl -sSL https://raw.githubusercontent.com/dot-matrix-labs/calypso/main/scripts/bootstrap-standards.sh | bash
 
-Then read docs/standards/calypso-blueprint.md before doing anything else.
+Then read ./prompts/process/scaffold-task.md before doing anything else.
 
 Context: I am replacing GitHub Projects for a software team of 3.
 ```
@@ -100,6 +100,7 @@ Once you go post-human, the stack goes lower. The constraints that TypeScript an
 
 - [Calypso Blueprint](prompts/blueprints/calypso-blueprint.md) — full architecture and process standard (TOC)
 - [UX Blueprint](prompts/blueprints/ux-blueprint.md) — UX posture, agent UX, beauty as a gate condition
-- [Data Security Blueprint](prompts/blueprints/data-security-blueprint.md) — agent auth, scopes, and security posture
+- [Data Blueprint](prompts/blueprints/data-blueprint.md) — data architecture, storage, and security posture
+- [Auth Blueprint](prompts/blueprints/auth-blueprint.md) — agent auth, scopes, and authentication
 - [Scaffold Task Entrypoint](prompts/process/scaffold-task.md) — the agent's first action on a new project
 - [Blueprint Authoring Standard](blueprint-standard.md) — how blueprints are written and structured

--- a/scripts/bootstrap-standards.sh
+++ b/scripts/bootstrap-standards.sh
@@ -1,37 +1,24 @@
 #!/bin/bash
 set -e
 
-# Create standards directory
-mkdir -p docs/standards
+REPO="https://github.com/dot-matrix-labs/calypso.git"
 
-# List of standard files to download (path:localname)
-FILES=(
-  "blueprints/calypso-blueprint.md:calypso-blueprint.md"
-  "development/development-standards.md:development-standards.md"
-  "process/documentation-standard.md:documentation-standard.md"
-  "process/git-standards.md:git-standards.md"
-  "process/product-owner-interview.md:product-owner-interview.md"
-  "process/scaffold-task.md:scaffold-task.md"
-)
+echo "Downloading Calypso prompts..."
 
-BASE_URL="https://raw.githubusercontent.com/dot-matrix-labs/calypso/main/prompts"
+git clone --depth=1 --filter=blob:none --sparse "$REPO" .calypso-bootstrap
+cd .calypso-bootstrap
+git sparse-checkout set prompts
+cd ..
 
-echo "Downloading Calypso standards..."
+cp -r .calypso-bootstrap/prompts ./prompts
+rm -rf .calypso-bootstrap
 
-for ENTRY in "${FILES[@]}"; do
-  REMOTE_PATH="${ENTRY%%:*}"
-  LOCAL_NAME="${ENTRY##*:}"
-  echo "  - $LOCAL_NAME"
-  curl -sSL "$BASE_URL/$REMOTE_PATH" -o "docs/standards/$LOCAL_NAME"
-done
-
-echo "Done. Standards saved to ./docs/standards/"
-
+echo ""
+echo "Done. Prompts saved to ./prompts/"
 echo ""
 echo "================================================================================"
 echo "AGENT INSTRUCTION:"
-echo "The agent MUST now read these local files in ./docs/standards/ as the first"
-echo "action of the session. Do NOT proceed with any development or documentation"
-echo "tasks until these standards are read; otherwise, you may fabricate"
-echo "conventions that violate the Calypso architecture."
+echo "The agent MUST read the files in ./prompts/ as the first action of the session."
+echo "Do NOT proceed with any development or documentation tasks until these are read;"
+echo "otherwise, you may fabricate conventions that violate the Calypso architecture."
 echo "================================================================================"


### PR DESCRIPTION
## Summary

- Replace stale hardcoded file list in `bootstrap-standards.sh` with a sparse `git clone` that mirrors the full `prompts/` directory — no `jq` or JSON parsing required
- Fix README Quickstart agent instruction to point to `./prompts/process/scaffold-task.md` instead of the stale `docs/standards/calypso-blueprint.md` path
- Fix dead `data-security-blueprint.md` doc link — replaced with the current `data-blueprint.md` and `auth-blueprint.md`

## Test plan

- [x] Run the bootstrap script in a clean directory and verify `prompts/` is populated with all subdirectories (blueprints, development, implementation-ts, process)
- [x] Confirm the README Quickstart prompt works end-to-end with a fresh agent session