### PR TITLE
feat: comprehensive repository and feature state tracking

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -45,6 +45,20 @@ fn main() {
             render_status(path)
         }
         [command, flag, path] if command == "status" && flag == "--state" => run_status_tui(path),
+        [command, subcommand] if command == "state" && subcommand == "show" => {
+            let cwd = std::env::current_dir().expect("current directory should resolve");
+            let state_path = cwd.join(".calypso").join("state.json");
+            match RepositoryState::load_from_path(&state_path) {
+                Ok(state) => println!(
+                    "{}",
+                    state.to_json_pretty().expect("state should serialize")
+                ),
+                Err(error) => {
+                    eprintln!("state show error: {error}");
+                    std::process::exit(1);
+                }
+            }
+        }
         [command, feature_id, flag, worktree_base]
             if command == "feature-start" && flag == "--worktree-base" =>
         {

--- a/cli/src/runtime.rs
+++ b/cli/src/runtime.rs
@@ -181,8 +181,15 @@ pub fn load_or_initialize_runtime(
 
         let state = RepositoryState {
             version: STATE_VERSION,
+            schema_version: 1,
             repo_id: context.repo_id.clone(),
             current_feature: feature,
+            identity: Default::default(),
+            providers: Vec::new(),
+            github_auth_ref: None,
+            secure_key_refs: Vec::new(),
+            active_features: Vec::new(),
+            known_worktrees: Vec::new(),
         };
 
         let runtime = RuntimeState {

--- a/cli/src/state.rs
+++ b/cli/src/state.rs
@@ -7,11 +7,73 @@ use serde::{Deserialize, Serialize};
 
 use crate::template::{AgentTaskKind, TemplateSet};
 
+/// Identity metadata for the repository. Contains no secrets.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct RepositoryIdentity {
+    pub name: String,
+    pub github_remote_url: String,
+    pub default_branch: String,
+}
+
+/// A reference to a secure credential. Contains only the reference identifier,
+/// never the raw secret value.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SecureKeyRef {
+    pub id: String,
+    pub name: String,
+    pub purpose: String,
+}
+
+/// A summary entry for an active feature, used in the repository-level index.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FeatureSummary {
+    pub feature_id: String,
+    pub branch: String,
+    pub worktree_path: String,
+    #[serde(default)]
+    pub pr_number: Option<u64>,
+    pub state: WorkflowState,
+}
+
+/// A summary of a known git worktree.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorktreeSummary {
+    pub path: String,
+    pub branch: String,
+    #[serde(default)]
+    pub feature_id: Option<String>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RepositoryState {
     pub version: u32,
     pub repo_id: String,
     pub current_feature: FeatureState,
+    /// Schema version for forward-compatibility. Defaults to 1.
+    #[serde(default = "default_schema_version")]
+    pub schema_version: u32,
+    /// Repository identity metadata.
+    #[serde(default)]
+    pub identity: RepositoryIdentity,
+    /// Names of configured providers (no secrets).
+    #[serde(default)]
+    pub providers: Vec<String>,
+    /// Token name or keychain reference for GitHub auth. Never the raw token.
+    #[serde(default)]
+    pub github_auth_ref: Option<String>,
+    /// References to secure keys. Contains only identifiers, never raw secrets.
+    #[serde(default)]
+    pub secure_key_refs: Vec<SecureKeyRef>,
+    /// Index of all active features.
+    #[serde(default)]
+    pub active_features: Vec<FeatureSummary>,
+    /// All known worktrees for this repository.
+    #[serde(default)]
+    pub known_worktrees: Vec<WorktreeSummary>,
+}
+
+fn default_schema_version() -> u32 {
+    1
 }
 
 impl RepositoryState {
@@ -23,15 +85,66 @@ impl RepositoryState {
         serde_json::from_str(json).map_err(StateError::Json)
     }
 
+    /// Atomically saves state by writing to a `.tmp` file then renaming into place.
     pub fn save_to_path(&self, path: &Path) -> Result<(), StateError> {
         let json = self.to_json_pretty()?;
-        fs::write(path, json).map_err(StateError::Io)
+        let tmp_path = path.with_extension("tmp");
+        fs::write(&tmp_path, json).map_err(StateError::Io)?;
+        fs::rename(&tmp_path, path).map_err(StateError::Io)
     }
 
     pub fn load_from_path(path: &Path) -> Result<Self, StateError> {
         let json = fs::read_to_string(path).map_err(StateError::Io)?;
         Self::from_json(&json)
     }
+}
+
+/// The type/category of a feature.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum FeatureType {
+    Feat,
+    Fix,
+    Chore,
+}
+
+/// A record of a role and its most recent session within a feature.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RoleSession {
+    pub role: String,
+    #[serde(default)]
+    pub session_id: Option<String>,
+    #[serde(default)]
+    pub last_outcome: Option<String>,
+}
+
+/// Scheduling and timing metadata for a feature.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct SchedulingMeta {
+    pub created_at: String,
+    #[serde(default)]
+    pub last_advanced_at: Option<String>,
+    #[serde(default)]
+    pub last_agent_run_at: Option<String>,
+}
+
+/// A reference to an artifact produced during feature work.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ArtifactRef {
+    pub kind: String,
+    pub path: String,
+    #[serde(default)]
+    pub session_id: Option<String>,
+}
+
+/// A single entry in the clarification history for a feature.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ClarificationEntry {
+    pub session_id: String,
+    pub question: String,
+    #[serde(default)]
+    pub answer: Option<String>,
+    pub timestamp: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -47,6 +160,28 @@ pub struct FeatureState {
     pub workflow_state: WorkflowState,
     pub gate_groups: Vec<GateGroup>,
     pub active_sessions: Vec<AgentSession>,
+    /// The type/category of this feature.
+    #[serde(default = "default_feature_type")]
+    pub feature_type: FeatureType,
+    /// Role sessions associated with this feature.
+    #[serde(default)]
+    pub roles: Vec<RoleSession>,
+    /// Scheduling and timing metadata.
+    #[serde(default)]
+    pub scheduling: SchedulingMeta,
+    /// References to artifacts produced during this feature.
+    #[serde(default)]
+    pub artifact_refs: Vec<ArtifactRef>,
+    /// Paths to transcript files.
+    #[serde(default)]
+    pub transcript_refs: Vec<String>,
+    /// History of clarification Q&A for this feature.
+    #[serde(default)]
+    pub clarification_history: Vec<ClarificationEntry>,
+}
+
+fn default_feature_type() -> FeatureType {
+    FeatureType::Feat
 }
 
 impl FeatureState {
@@ -87,6 +222,12 @@ impl FeatureState {
                 })
                 .collect(),
             active_sessions: Vec::new(),
+            feature_type: FeatureType::Feat,
+            roles: Vec::new(),
+            scheduling: SchedulingMeta::default(),
+            artifact_refs: Vec::new(),
+            transcript_refs: Vec::new(),
+            clarification_history: Vec::new(),
         })
     }
 

--- a/cli/tests/app.rs
+++ b/cli/tests/app.rs
@@ -18,8 +18,8 @@ static EXEC_LOCK: LazyLock<RwLock<()>> = LazyLock::new(|| RwLock::new(()));
 static PATH_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
 use calypso_cli::state::{
-    EvidenceStatus, FeatureState, Gate, GateGroup, GateStatus, GithubMergeability,
-    GithubPullRequestSnapshot, GithubReviewStatus, PullRequestRef, WorkflowState,
+    EvidenceStatus, FeatureState, FeatureType, Gate, GateGroup, GateStatus, GithubMergeability,
+    GithubPullRequestSnapshot, GithubReviewStatus, PullRequestRef, SchedulingMeta, WorkflowState,
 };
 
 fn feature_with_gate_statuses(statuses: &[GateStatus]) -> FeatureState {
@@ -49,6 +49,12 @@ fn feature_with_gate_statuses(statuses: &[GateStatus]) -> FeatureState {
                 .collect(),
         }],
         active_sessions: Vec::new(),
+        feature_type: FeatureType::Feat,
+        roles: Vec::new(),
+        scheduling: SchedulingMeta::default(),
+        artifact_refs: Vec::new(),
+        transcript_refs: Vec::new(),
+        clarification_history: Vec::new(),
     }
 }
 

--- a/cli/tests/cli.rs
+++ b/cli/tests/cli.rs
@@ -2,8 +2,9 @@ use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use calypso_cli::state::{
-    AgentSession, AgentSessionStatus, FeatureState, Gate, GateGroup, GateStatus, PullRequestRef,
-    RepositoryState, SessionOutput, SessionOutputStream, WorkflowState,
+    AgentSession, AgentSessionStatus, FeatureState, FeatureType, Gate, GateGroup, GateStatus,
+    PullRequestRef, RepositoryIdentity, RepositoryState, SchedulingMeta, SessionOutput,
+    SessionOutputStream, WorkflowState,
 };
 
 fn temp_state_path() -> std::path::PathBuf {
@@ -17,7 +18,14 @@ fn temp_state_path() -> std::path::PathBuf {
 fn sample_state() -> RepositoryState {
     RepositoryState {
         version: 1,
+        schema_version: 1,
         repo_id: "acme-api".to_string(),
+        identity: RepositoryIdentity::default(),
+        providers: Vec::new(),
+        github_auth_ref: None,
+        secure_key_refs: Vec::new(),
+        active_features: Vec::new(),
+        known_worktrees: Vec::new(),
         current_feature: FeatureState {
             feature_id: "feat-tui-surface".to_string(),
             branch: "feat/cli-tui-operator-surface".to_string(),
@@ -51,6 +59,12 @@ fn sample_state() -> RepositoryState {
                 pending_follow_ups: Vec::new(),
                 terminal_outcome: None,
             }],
+            feature_type: FeatureType::Feat,
+            roles: Vec::new(),
+            scheduling: SchedulingMeta::default(),
+            artifact_refs: Vec::new(),
+            transcript_refs: Vec::new(),
+            clarification_history: Vec::new(),
         },
     }
 }

--- a/cli/tests/state.rs
+++ b/cli/tests/state.rs
@@ -4,16 +4,24 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use calypso_cli::state::{
     AgentSession, AgentSessionStatus, AgentTerminalOutcome, BuiltinEvidence, EvidenceStatus,
-    FeatureState, Gate, GateEvaluationError, GateGroup, GateGroupStatus, GateInitializationError,
-    GateStatus, PullRequestRef, RepositoryState, SessionOutput, SessionOutputStream, StateError,
-    TransitionError, TransitionFacts, WorkflowState,
+    FeatureState, FeatureType, Gate, GateEvaluationError, GateGroup, GateGroupStatus,
+    GateInitializationError, GateStatus, PullRequestRef, RepositoryIdentity, RepositoryState,
+    SchedulingMeta, SessionOutput, SessionOutputStream, StateError, TransitionError,
+    TransitionFacts, WorkflowState,
 };
 use calypso_cli::template::{TemplateSet, load_embedded_template_set};
 
 fn sample_state() -> RepositoryState {
     RepositoryState {
         version: 1,
+        schema_version: 1,
         repo_id: "acme-api".to_string(),
+        identity: RepositoryIdentity::default(),
+        providers: Vec::new(),
+        github_auth_ref: None,
+        secure_key_refs: Vec::new(),
+        active_features: Vec::new(),
+        known_worktrees: Vec::new(),
         current_feature: FeatureState {
             feature_id: "feat-auth-refresh".to_string(),
             branch: "feat/123-token-refresh".to_string(),
@@ -59,6 +67,12 @@ fn sample_state() -> RepositoryState {
                 pending_follow_ups: vec!["Please include the diff".to_string()],
                 terminal_outcome: None,
             }],
+            feature_type: FeatureType::Feat,
+            roles: Vec::new(),
+            scheduling: SchedulingMeta::default(),
+            artifact_refs: Vec::new(),
+            transcript_refs: Vec::new(),
+            clarification_history: Vec::new(),
         },
     }
 }

--- a/cli/tests/state_v2.rs
+++ b/cli/tests/state_v2.rs
@@ -1,0 +1,229 @@
+use std::fs;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use calypso_cli::state::{
+    ArtifactRef, ClarificationEntry, FeatureState, FeatureSummary, FeatureType, Gate, GateGroup,
+    GateStatus, PullRequestRef, RepositoryIdentity, RepositoryState, RoleSession, SchedulingMeta,
+    SecureKeyRef, WorkflowState, WorktreeSummary,
+};
+
+fn temp_path(suffix: &str) -> PathBuf {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after unix epoch")
+        .as_nanos();
+    std::env::temp_dir().join(format!("calypso-state-v2-{unique}-{suffix}"))
+}
+
+fn minimal_feature_state(id: &str) -> FeatureState {
+    FeatureState {
+        feature_id: id.to_string(),
+        branch: format!("feat/{id}"),
+        worktree_path: format!("/worktrees/{id}"),
+        pull_request: PullRequestRef {
+            number: 1,
+            url: "https://github.com/org/repo/pull/1".to_string(),
+        },
+        github_snapshot: None,
+        github_error: None,
+        workflow_state: WorkflowState::Implementation,
+        gate_groups: vec![GateGroup {
+            id: "validation".to_string(),
+            label: "Validation".to_string(),
+            gates: vec![Gate {
+                id: "test-gate".to_string(),
+                label: "Test gate".to_string(),
+                task: "test-task".to_string(),
+                status: GateStatus::Pending,
+            }],
+        }],
+        active_sessions: Vec::new(),
+        feature_type: FeatureType::Feat,
+        roles: Vec::new(),
+        scheduling: SchedulingMeta::default(),
+        artifact_refs: Vec::new(),
+        transcript_refs: Vec::new(),
+        clarification_history: Vec::new(),
+    }
+}
+
+fn full_repository_state() -> RepositoryState {
+    RepositoryState {
+        version: 1,
+        schema_version: 1,
+        repo_id: "test-repo".to_string(),
+        identity: RepositoryIdentity {
+            name: "my-org/test-repo".to_string(),
+            github_remote_url: "https://github.com/my-org/test-repo.git".to_string(),
+            default_branch: "main".to_string(),
+        },
+        providers: vec!["openai".to_string(), "anthropic".to_string()],
+        github_auth_ref: Some("GITHUB_TOKEN_REF".to_string()),
+        secure_key_refs: vec![SecureKeyRef {
+            id: "key-001".to_string(),
+            name: "OpenAI API Key".to_string(),
+            purpose: "llm-provider".to_string(),
+        }],
+        active_features: vec![FeatureSummary {
+            feature_id: "feat-auth".to_string(),
+            branch: "feat/auth".to_string(),
+            worktree_path: "/worktrees/feat-auth".to_string(),
+            pr_number: Some(42),
+            state: WorkflowState::Implementation,
+        }],
+        known_worktrees: vec![WorktreeSummary {
+            path: "/worktrees/feat-auth".to_string(),
+            branch: "feat/auth".to_string(),
+            feature_id: Some("feat-auth".to_string()),
+        }],
+        current_feature: minimal_feature_state("feat-auth"),
+    }
+}
+
+#[test]
+fn repository_state_with_all_new_fields_round_trips_through_json() {
+    let state = full_repository_state();
+    let json = state.to_json_pretty().expect("state should serialize");
+    let restored = RepositoryState::from_json(&json).expect("state should deserialize");
+    assert_eq!(restored, state);
+}
+
+#[test]
+fn feature_state_with_roles_artifacts_and_clarification_history_round_trips() {
+    let mut feature = minimal_feature_state("feat-complex");
+    feature.feature_type = FeatureType::Fix;
+    feature.roles = vec![
+        RoleSession {
+            role: "engineer".to_string(),
+            session_id: Some("sess-001".to_string()),
+            last_outcome: Some("ok".to_string()),
+        },
+        RoleSession {
+            role: "reviewer".to_string(),
+            session_id: None,
+            last_outcome: None,
+        },
+    ];
+    feature.scheduling = SchedulingMeta {
+        created_at: "2024-01-01T00:00:00Z".to_string(),
+        last_advanced_at: Some("2024-01-02T00:00:00Z".to_string()),
+        last_agent_run_at: Some("2024-01-03T00:00:00Z".to_string()),
+    };
+    feature.artifact_refs = vec![ArtifactRef {
+        kind: "screenshot".to_string(),
+        path: "/tmp/screenshot.png".to_string(),
+        session_id: Some("sess-001".to_string()),
+    }];
+    feature.transcript_refs = vec!["/tmp/transcripts/sess-001.jsonl".to_string()];
+    feature.clarification_history = vec![ClarificationEntry {
+        session_id: "sess-001".to_string(),
+        question: "Should we use async?".to_string(),
+        answer: Some("Yes, please use tokio.".to_string()),
+        timestamp: "2024-01-01T01:00:00Z".to_string(),
+    }];
+
+    let json = serde_json::to_string_pretty(&feature).expect("feature should serialize");
+    let restored: FeatureState = serde_json::from_str(&json).expect("feature should deserialize");
+    assert_eq!(restored, feature);
+}
+
+#[test]
+fn save_to_path_uses_atomic_rename_no_tmp_file_remains() {
+    let path = temp_path("atomic.json");
+    let tmp_path = path.with_extension("tmp");
+    let state = full_repository_state();
+
+    state.save_to_path(&path).expect("state should save");
+
+    assert!(path.exists(), "final state file should exist");
+    assert!(!tmp_path.exists(), ".tmp file should not remain after save");
+
+    fs::remove_file(&path).expect("temp state file should be removed");
+}
+
+#[test]
+fn loading_state_file_with_unknown_field_succeeds() {
+    let path = temp_path("unknown-field.json");
+    // Write JSON with an extra unknown field that didn't exist before
+    let json = r#"{
+        "version": 1,
+        "repo_id": "test",
+        "schema_version": 1,
+        "future_unknown_field": "some value",
+        "current_feature": {
+            "feature_id": "feat-x",
+            "branch": "feat/x",
+            "worktree_path": "/worktrees/x",
+            "pull_request": { "number": 1, "url": "https://github.com/o/r/pull/1" },
+            "workflow_state": "new",
+            "gate_groups": [],
+            "active_sessions": []
+        }
+    }"#;
+    fs::write(&path, json).expect("fixture should write");
+
+    let result = RepositoryState::load_from_path(&path);
+    assert!(
+        result.is_ok(),
+        "loading state with unknown fields should succeed, got: {:?}",
+        result.err()
+    );
+
+    fs::remove_file(&path).expect("temp file should be removed");
+}
+
+#[test]
+fn schema_version_defaults_to_one_when_absent_from_old_state_file() {
+    let json = r#"{
+        "version": 1,
+        "repo_id": "legacy-repo",
+        "current_feature": {
+            "feature_id": "feat-legacy",
+            "branch": "feat/legacy",
+            "worktree_path": "/worktrees/legacy",
+            "pull_request": { "number": 10, "url": "https://github.com/o/r/pull/10" },
+            "workflow_state": "implementation",
+            "gate_groups": [],
+            "active_sessions": []
+        }
+    }"#;
+
+    let state = RepositoryState::from_json(json).expect("old state should deserialize");
+    assert_eq!(
+        state.schema_version, 1,
+        "schema_version should default to 1 when absent"
+    );
+}
+
+#[test]
+fn feature_type_enum_serializes_with_kebab_case() {
+    assert_eq!(
+        serde_json::to_string(&FeatureType::Feat).expect("should serialize"),
+        "\"feat\""
+    );
+    assert_eq!(
+        serde_json::to_string(&FeatureType::Fix).expect("should serialize"),
+        "\"fix\""
+    );
+    assert_eq!(
+        serde_json::to_string(&FeatureType::Chore).expect("should serialize"),
+        "\"chore\""
+    );
+}
+
+#[test]
+fn feature_state_feature_type_defaults_to_feat_when_absent() {
+    let json = r#"{
+        "feature_id": "feat-default",
+        "branch": "feat/default",
+        "worktree_path": "/worktrees/default",
+        "pull_request": { "number": 1, "url": "https://github.com/o/r/pull/1" },
+        "workflow_state": "new",
+        "gate_groups": [],
+        "active_sessions": []
+    }"#;
+
+    let feature: FeatureState = serde_json::from_str(json).expect("feature should deserialize");
+    assert_eq!(feature.feature_type, FeatureType::Feat);
+}

--- a/cli/tests/tui.rs
+++ b/cli/tests/tui.rs
@@ -1,9 +1,9 @@
 use crossterm::event::{KeyCode, KeyEvent};
 
 use calypso_cli::state::{
-    AgentSession, AgentSessionStatus, EvidenceStatus, FeatureState, Gate, GateGroup, GateStatus,
-    GithubMergeability, GithubPullRequestSnapshot, GithubReviewStatus, PullRequestRef,
-    SessionOutput, SessionOutputStream, WorkflowState,
+    AgentSession, AgentSessionStatus, EvidenceStatus, FeatureState, FeatureType, Gate, GateGroup,
+    GateStatus, GithubMergeability, GithubPullRequestSnapshot, GithubReviewStatus, PullRequestRef,
+    SchedulingMeta, SessionOutput, SessionOutputStream, WorkflowState,
 };
 use calypso_cli::tui::{InputBuffer, OperatorSurface, SurfaceEvent, queue_follow_up};
 
@@ -59,6 +59,12 @@ fn sample_feature() -> FeatureState {
             pending_follow_ups: Vec::new(),
             terminal_outcome: None,
         }],
+        feature_type: FeatureType::Feat,
+        roles: Vec::new(),
+        scheduling: SchedulingMeta::default(),
+        artifact_refs: Vec::new(),
+        transcript_refs: Vec::new(),
+        clarification_history: Vec::new(),
     }
 }
 


### PR DESCRIPTION
## Summary

- Expands `RepositoryState` with `identity`, `providers`, `github_auth_ref`, `secure_key_refs`, `active_features`, `known_worktrees`, and `schema_version` — all reference-only, no secrets serialized
- Expands `FeatureState` with `feature_type`, `roles`, `scheduling`, `artifact_refs`, `transcript_refs`, and `clarification_history`
- Upgrades `save_to_path` to an atomic write-then-rename pattern (write to `.tmp`, then `fs::rename`) to eliminate partial-write corruption on crash
- Adds `calypso state show` subcommand that loads and pretty-prints the current `RepositoryState` as JSON
- New `cli/tests/state_v2.rs` test suite covers all new fields, the atomic save guarantee, unknown-field tolerance, and `schema_version` defaulting to 1 for old state files

## Key decisions

- All new fields on both structs use `#[serde(default)]` so existing state files deserialize without error — `deny_unknown_fields` is not set
- `FeatureType` defaults to `Feat` via a dedicated `default_feature_type()` function to keep the default value explicit and greppable
- `schema_version` uses a named `default_schema_version()` function (returns `1`) rather than a `Default` impl so the sentinel value is co-located with the field declaration
- `RepositoryIdentity` derives `Default` since all its string fields are naturally empty-string safe as a zero-value

## Test plan

- All 164 existing tests continue to pass (`cargo test -p calypso-cli`)
- 7 new tests in `state_v2.rs`:
  - `repository_state_with_all_new_fields_round_trips_through_json`
  - `feature_state_with_roles_artifacts_and_clarification_history_round_trips`
  - `save_to_path_uses_atomic_rename_no_tmp_file_remains`
  - `loading_state_file_with_unknown_field_succeeds`
  - `schema_version_defaults_to_one_when_absent_from_old_state_file`
  - `feature_type_enum_serializes_with_kebab_case`
  - `feature_state_feature_type_defaults_to_feat_when_absent`