### PR TITLE
ci: require all PR checklist items to be checked before merge

### DIFF
--- a/.github/workflows/pr-checklist.yml
+++ b/.github/workflows/pr-checklist.yml
@@ -1,0 +1,26 @@
+name: PR checklist
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  checklist:
+    name: checklist
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Require all task items to be checked
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.pull_request.body || '';
+            const incomplete = (body.match(/- \[ \]/g) || []).length;
+            if (incomplete > 0) {
+              core.setFailed(
+                `${incomplete} unchecked task item${incomplete === 1 ? '' : 's'} in PR description. ` +
+                `Complete all checklist items before merging.`
+              );
+            } else {
+              core.info('All checklist items are checked.');
+            }


### PR DESCRIPTION
## Summary

- Adds a \`pr-checklist\` workflow that fails if any \`- [ ]\` task items remain in the PR description
- This check will be added as a required status check on the \`main\` ruleset so incomplete PRs cannot be merged

## Test plan

- [x] Workflow file is valid YAML
- [x] Check fires on PR open, edit, synchronize, and reopen events
- [x] Passes when all items are checked
- [x] Fails with a clear count when unchecked items remain