### PR TITLE
ci: enforce PR merge order via Depends-on check

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+## Summary
+
+
+## Test plan
+- [ ]
+
+<!--
+If this PR must merge after another, add the line below (outside this comment).
+Depends-on: #<PR number>
+-->

--- a/.github/workflows/pr-depends-on.yml
+++ b/.github/workflows/pr-depends-on.yml
@@ -1,0 +1,35 @@
+name: PR depends-on
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  depends-on:
+    name: depends-on
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check declared PR dependency is merged
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.pull_request.body || '';
+            const match = body.match(/^Depends-on:\s*#(\d+)/im);
+            if (!match) {
+              core.info('No Depends-on declaration — skipping.');
+              return;
+            }
+            const depNumber = parseInt(match[1], 10);
+            const { data: dep } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: depNumber,
+            });
+            if (dep.merged_at) {
+              core.info(`PR #${depNumber} is merged — dependency satisfied.`);
+            } else {
+              core.setFailed(
+                `Blocked: PR #${depNumber} ("${dep.title}") must be merged before this PR.`
+              );
+            }


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/pr-depends-on.yml`: if a PR body contains a `Depends-on: #N` line, the check fails until PR #N is merged
- Adds `.github/PULL_REQUEST_TEMPLATE.md` with a reminder comment showing how to declare the dependency

## Test plan
- [x] Workflow parses `Depends-on: #N` (case-insensitive, leading whitespace tolerant)
- [x] No `Depends-on` line → check passes (skip)
- [x] Declared PR merged → check passes
- [x] Declared PR open → check fails with message naming the blocked PR