### PR TITLE
ci: lower coverage gate to 90% until Phase 3

### DIFF
--- a/.github/workflows/rust-coverage.yml
+++ b/.github/workflows/rust-coverage.yml
@@ -25,7 +25,7 @@ jobs:
           workspaces: |
             cli -> target
 
-      - name: Run coverage with 99% line threshold
+      - name: Run coverage with 90% line threshold
         working-directory: cli
         run: cargo coverage
 
@@ -41,5 +41,5 @@ jobs:
         run: |
           echo "## CLI Coverage" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Enforced line coverage target: 99%" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Enforced line coverage target: 90% (returns to 99% at Phase 3)" >> "$GITHUB_STEP_SUMMARY"
           echo "- LCOV artifact: cli-coverage-lcov" >> "$GITHUB_STEP_SUMMARY"

--- a/cli/src/bin/coverage_driver.rs
+++ b/cli/src/bin/coverage_driver.rs
@@ -33,14 +33,14 @@ fn run() -> Result<(), String> {
         Ok(())
     } else {
         Err(format!(
-            "Line coverage below target: {covered}/{total} ({:.2}% < 99.00%)",
+            "Line coverage below target: {covered}/{total} ({:.2}% < 90.00%)",
             coverage_percent(covered, total)
         ))
     }
 }
 
 fn meets_line_threshold(covered: u64, total: u64) -> bool {
-    coverage_percent(covered, total) >= 99.0
+    coverage_percent(covered, total) >= 90.0
 }
 
 fn coverage_percent(covered: u64, total: u64) -> f64 {
@@ -109,8 +109,8 @@ end_of_record
 
     #[test]
     fn line_threshold_accepts_99_percent_or_more() {
-        assert!(meets_line_threshold(99, 100));
+        assert!(meets_line_threshold(90, 100));
         assert!(meets_line_threshold(100, 100));
-        assert!(!meets_line_threshold(98, 100));
+        assert!(!meets_line_threshold(89, 100));
     }
 }


### PR DESCRIPTION
## Summary
- Drops the enforced line coverage threshold from 99% to 90% for Phase 1 and Phase 2
- Will be reverted to 99% at the start of Phase 3 (see #47)

## Key decisions
- Phase 1/2 features add substantial new code rapidly; chasing 99% coverage on every PR is slowing merge velocity without proportional safety benefit at this stage
- 90% still catches gross regressions; thorough coverage enforcement returns when the codebase stabilises at Phase 3

## Test plan
- [x] `meets_line_threshold` test updated to assert 90%/89% boundary
- [x] Workflow step name and summary updated to reflect new target