### PR TITLE
feat: build metadata and version/help output

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -24,7 +24,7 @@ pub struct BuildInfo<'a> {
 
 pub fn render_version(info: BuildInfo<'_>) -> String {
     format!(
-        "calypso-cli {}\nGit hash: {}\nBuild time: {}\nGit tags: {}",
+        "calypso-cli {} git:{} built:{} tags:{}",
         info.version, info.git_hash, info.build_time, info.git_tags
     )
 }
@@ -53,10 +53,16 @@ mod tests {
     fn version_output_contains_required_build_metadata() {
         let output = render_version(sample_info());
 
-        assert!(output.contains("0.1.0+abc123"));
-        assert!(output.contains("abc123"));
-        assert!(output.contains("2026-03-13T12:00:00Z"));
-        assert!(output.contains("v0.1.0"));
+        assert!(output.contains("0.1.0+abc123"), "missing semver+hash");
+        assert!(output.contains("abc123"), "missing git hash");
+        assert!(output.contains("2026-03-13T12:00:00Z"), "missing timestamp");
+        assert!(output.contains("v0.1.0"), "missing git tag");
+    }
+
+    #[test]
+    fn version_output_is_a_single_line() {
+        let output = render_version(sample_info());
+        assert_eq!(output.lines().count(), 1, "version output must be one line");
     }
 
     #[test]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -28,7 +28,10 @@ fn main() {
     let args: Vec<String> = std::env::args().skip(1).collect();
 
     match args.as_slice() {
-        [flag] if flag == "-v" || flag == "--version" => println!("{}", render_version(info)),
+        [flag] if flag == "-v" || flag == "-V" || flag == "--version" => {
+            println!("{}", render_version(info))
+        }
+        [flag] if flag == "-h" || flag == "--help" => println!("{}", render_help(info)),
         [command] if command == "doctor" => {
             let cwd = std::env::current_dir().expect("current directory should resolve");
             println!("{}", run_doctor(&cwd));

--- a/cli/tests/cli.rs
+++ b/cli/tests/cli.rs
@@ -82,9 +82,15 @@ fn version_flag_prints_required_build_metadata() {
 
     let stdout = String::from_utf8(output.stdout).expect("stdout should be valid utf-8");
     assert!(stdout.contains("calypso-cli "));
-    assert!(stdout.contains("Git hash: "));
-    assert!(stdout.contains("Build time: "));
-    assert!(stdout.contains("Git tags: "));
+    assert!(stdout.contains("git:"));
+    assert!(stdout.contains("built:"));
+    assert!(stdout.contains("tags:"));
+    // version output must be a single line
+    assert_eq!(
+        stdout.trim().lines().count(),
+        1,
+        "version output must be one line"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #45

## Summary

- Adds compile-time build metadata injection via `build.rs`: git commit hash, build timestamp, git tags, all set as `CALYPSO_BUILD_*` env vars consumed by `env!` macros — no runtime `git` invocations
- `calypso --version` / `-v` / `-V` prints a single machine-parseable line: `calypso-cli <semver+hash> git:<hash> built:<timestamp> tags:<tags>`
- `calypso --help` / `-h` prints a structured usage block including version, commands, and options
- `build.rs` falls back to `"unknown"` / `"none"` if git is unavailable (e.g. shallow CI clones)

## Test plan

- [x] `cargo test -p calypso-cli` — all tests pass including new `version_output_is_a_single_line` unit test and updated `version_flag_prints_required_build_metadata` integration test
- [x] `cargo clippy -- -D warnings` — no warnings
- [x] `cargo fmt -- --check` — clean
- [x] `--version` output is a single line matching `calypso-cli <ver> git:<hash> built:<ts> tags:<tags>`
- [x] `-v`, `-V`, and `--version` all handled
- [x] `-h` and `--help` both handled explicitly