### PR TITLE
ci: add merge_group trigger to all CLI test workflows

### DIFF
--- a/.github/workflows/rust-coverage.yml
+++ b/.github/workflows/rust-coverage.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main, "feat/**"]
   pull_request:
+  merge_group:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/rust-e2e.yml
+++ b/.github/workflows/rust-e2e.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main, "feat/**"]
   pull_request:
+  merge_group:
   schedule:
     - cron: "35 1 * * *"
   workflow_dispatch:

--- a/.github/workflows/rust-integration.yml
+++ b/.github/workflows/rust-integration.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main, "feat/**"]
   pull_request:
+  merge_group:
   schedule:
     - cron: "25 1 * * *"
   workflow_dispatch:

--- a/.github/workflows/rust-quality.yml
+++ b/.github/workflows/rust-quality.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main, "feat/**"]
   pull_request:
+  merge_group:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/rust-unit.yml
+++ b/.github/workflows/rust-unit.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main, "feat/**"]
   pull_request:
+  merge_group:
   schedule:
     - cron: "15 1 * * *"
   workflow_dispatch:


### PR DESCRIPTION
## Summary
The merge queue (enabled on main) was stuck `AWAITING_CHECKS` because the Rust CI workflows only trigger on `pull_request` and `push` to `main`/`feat/**` — not on `merge_group` events. Added `merge_group:` trigger to all 5 CLI test workflows so the queue can run checks and proceed.

## Key decisions
- `merge_group` added alongside existing `pull_request` trigger — no other changes
- Applies to: `rust-quality`, `rust-coverage`, `rust-e2e`, `rust-integration`, `rust-unit`

## Test plan
- [x] Merge queue unblocks and processes queued PRs after this lands