### PR TITLE
fix: launch doctor TUI by default when no state file

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -5,7 +5,7 @@ use calypso_cli::feature_start::{FeatureStartRequest, run_feature_start};
 use calypso_cli::init::{HostInitEnvironment, run_init_interactive};
 use calypso_cli::state::RepositoryState;
 use calypso_cli::template::TemplateSet;
-use calypso_cli::tui::{OperatorSurface, run_terminal_surface, run_watch};
+use calypso_cli::tui::{OperatorSurface, run_doctor_surface, run_terminal_surface, run_watch};
 use calypso_cli::{BuildInfo, render_help, render_version};
 
 fn build_info() -> BuildInfo<'static> {
@@ -133,9 +133,9 @@ fn main() {
             let project_dir = std::path::Path::new(path);
             let state_path = project_dir.join(".calypso").join("state.json");
             if state_path.exists() {
-                run_watch(&state_path.to_string_lossy());
+                run_state_machine_auto(&state_path);
             } else {
-                println!("{}", render_help(info));
+                run_doctor_surface(project_dir).unwrap_or_else(|e| eprintln!("tui error: {e}"));
             }
         }
         // calypso --step — step mode: one step per Enter keypress
@@ -145,17 +145,17 @@ fn main() {
             if state_path.exists() {
                 run_state_machine_step(&state_path);
             } else {
-                println!("{}", render_help(info));
+                run_doctor_surface(&cwd).unwrap_or_else(|e| eprintln!("tui error: {e}"));
             }
         }
-        // calypso — no args, drive the state machine automatically
+        // calypso — no args: drive state machine if initialized, else show doctor TUI
         [] => {
             let cwd = std::env::current_dir().expect("current directory should resolve");
             let state_path = cwd.join(".calypso").join("state.json");
             if state_path.exists() {
                 run_state_machine_auto(&state_path);
             } else {
-                println!("{}", render_help(info));
+                run_doctor_surface(&cwd).unwrap_or_else(|e| eprintln!("tui error: {e}"));
             }
         }
         _ => println!("{}", render_help(info)),

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -1,13 +1,37 @@
 use std::process::Command;
 
 #[test]
-fn running_without_arguments_shows_help_output() {
+fn running_without_arguments_exits_cleanly() {
+    // With no .calypso/state.json in the test working directory, the binary
+    // attempts to launch the doctor TUI. In a non-terminal environment the TUI
+    // setup fails gracefully and the process exits 0.
     let output = Command::new(env!("CARGO_BIN_EXE_calypso-cli"))
         .output()
         .expect("failed to run calypso-cli");
 
     assert!(output.status.success());
+}
 
+#[test]
+fn version_flag_prints_version() {
+    let output = Command::new(env!("CARGO_BIN_EXE_calypso-cli"))
+        .arg("--version")
+        .output()
+        .expect("failed to run calypso-cli");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be valid utf-8");
+    assert!(stdout.contains("0.1.0"));
+}
+
+#[test]
+fn help_flag_prints_usage() {
+    let output = Command::new(env!("CARGO_BIN_EXE_calypso-cli"))
+        .arg("help")
+        .output()
+        .expect("failed to run calypso-cli");
+
+    assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).expect("stdout should be valid utf-8");
     assert!(stdout.contains("Usage:"));
     assert!(stdout.contains("Commands:"));


### PR DESCRIPTION
## Summary

- `calypso` with no args now launches the `DoctorSurface` TUI when there is no `.calypso/state.json` (uninitialized project), instead of falling back to help text
- Same fallback for `calypso <path>` and `calypso --step` when the target has no state file
- In non-terminal environments (CI, pipes) crossterm fails gracefully and the process exits 0
- Also fixes path arg: was calling `run_watch` (read-only TUI), now calls `run_state_machine_auto` consistent with the no-arg arm

## Key decisions

- Doctor TUI is the natural entry point before `calypso init` — shows which prerequisites are met
- No help text fallback: if you want help, pass `help` as a subcommand or `--version`

## Test plan

- [x] `cargo run` from an uninitialized directory → doctor TUI launches (exits cleanly in CI non-terminal)
- [x] `cargo run` from an initialized project → state machine driver runs
- [x] e2e test updated: `running_without_arguments_exits_cleanly` (exit 0, no stdout assertions); added `version_flag_prints_version` and `help_flag_prints_usage` tests