### PR TITLE
fix: doctor checks — drop feature-binding, fix remote detection, use git for hooks path

### DIFF
--- a/cli/src/doctor.rs
+++ b/cli/src/doctor.rs
@@ -2,7 +2,6 @@ use std::path::Path;
 use std::process::Command;
 
 use crate::claude::{ClaudeConfig, ClaudeSession};
-use crate::runtime::discover_current_repository_context;
 use crate::state::BuiltinEvidence;
 
 const REQUIRED_WORKFLOW_FILES: [&str; 6] = [
@@ -21,7 +20,6 @@ pub enum DoctorCheckId {
     ClaudeInstalled,
     GhAuthenticated,
     GithubRemoteConfigured,
-    FeatureBindingResolved,
     RequiredWorkflowFilesPresent,
 }
 
@@ -33,7 +31,6 @@ impl DoctorCheckId {
             DoctorCheckId::ClaudeInstalled => "builtin.doctor.claude_installed",
             DoctorCheckId::GhAuthenticated => "builtin.doctor.gh_authenticated",
             DoctorCheckId::GithubRemoteConfigured => "builtin.doctor.github_remote_configured",
-            DoctorCheckId::FeatureBindingResolved => "builtin.doctor.feature_binding_resolved",
             DoctorCheckId::RequiredWorkflowFilesPresent => {
                 "builtin.doctor.required_workflows_present"
             }
@@ -47,7 +44,6 @@ impl DoctorCheckId {
             DoctorCheckId::ClaudeInstalled => "claude-installed",
             DoctorCheckId::GhAuthenticated => "gh-authenticated",
             DoctorCheckId::GithubRemoteConfigured => "github-remote-configured",
-            DoctorCheckId::FeatureBindingResolved => "feature-binding-resolved",
             DoctorCheckId::RequiredWorkflowFilesPresent => "required-workflows-present",
         }
     }
@@ -107,7 +103,6 @@ pub trait DoctorEnvironment {
     fn claude_reachable(&self) -> bool;
     fn gh_authenticated(&self) -> bool;
     fn has_github_remote(&self, repo_root: &Path) -> bool;
-    fn feature_binding_status(&self, repo_root: &Path) -> Result<(), String>;
     fn missing_workflow_files(&self, repo_root: &Path) -> Vec<String>;
 }
 
@@ -134,21 +129,11 @@ impl DoctorEnvironment for HostDoctorEnvironment {
     }
 
     fn has_github_remote(&self, repo_root: &Path) -> bool {
-        Command::new("git")
-            .args(["remote", "-v"])
+        Command::new("gh")
+            .args(["repo", "view", "--json", "nameWithOwner"])
             .current_dir(repo_root)
             .output()
-            .ok()
-            .filter(|output| output.status.success())
-            .is_some_and(|output| {
-                git_remote_output_has_github_remote(&String::from_utf8_lossy(&output.stdout))
-            })
-    }
-
-    fn feature_binding_status(&self, repo_root: &Path) -> Result<(), String> {
-        discover_current_repository_context(repo_root)
-            .map(|_| ())
-            .map_err(|error| error.to_string())
+            .is_ok_and(|output| output.status.success())
     }
 
     fn missing_workflow_files(&self, repo_root: &Path) -> Vec<String> {
@@ -167,7 +152,6 @@ pub fn collect_doctor_report(
     environment: &impl DoctorEnvironment,
     repo_root: &Path,
 ) -> DoctorReport {
-    let feature_binding_status = environment.feature_binding_status(repo_root);
     let mut missing_workflow_files = environment.missing_workflow_files(repo_root);
     missing_workflow_files.sort();
 
@@ -202,12 +186,6 @@ pub fn collect_doctor_report(
                 DoctorCheckScope::LocalConfiguration,
                 environment.has_github_remote(repo_root),
                 None,
-            ),
-            make_check(
-                DoctorCheckId::FeatureBindingResolved,
-                DoctorCheckScope::LocalConfiguration,
-                feature_binding_status.is_ok(),
-                feature_binding_status.err(),
             ),
             make_check(
                 DoctorCheckId::RequiredWorkflowFilesPresent,
@@ -249,14 +227,6 @@ fn make_check(
         remediation,
         fix,
     }
-}
-
-pub fn git_remote_output_has_github_remote(output: &str) -> bool {
-    output.lines().any(|line| {
-        line.contains("github.com/")
-            || line.contains("github.com:")
-            || line.contains("git@github.com")
-    })
 }
 
 pub fn render_doctor_report(report: &DoctorReport) -> String {
@@ -367,9 +337,6 @@ fn failing_doctor_fix(id: DoctorCheckId, detail: Option<&str>) -> Option<DoctorF
                 "Add a GitHub remote: git remote add origin https://github.com/org/repo.git"
                     .to_string(),
         }),
-        DoctorCheckId::FeatureBindingResolved => Some(DoctorFix::Manual {
-            instructions: "Run calypso init to initialize the repository".to_string(),
-        }),
         DoctorCheckId::RequiredWorkflowFilesPresent => Some(DoctorFix::Manual {
             instructions: format!(
                 "Run calypso init to scaffold required GitHub Actions workflows (missing: {})",
@@ -395,10 +362,6 @@ fn failing_fix(id: DoctorCheckId, detail: Option<&str>) -> Option<String> {
         }
         DoctorCheckId::GithubRemoteConfigured => Some(
             "Add a GitHub remote such as `git remote add origin git@github.com:<owner>/<repo>.git`."
-                .to_string(),
-        ),
-        DoctorCheckId::FeatureBindingResolved => Some(
-            "Ensure this worktree is on a feature branch with an open GitHub pull request."
                 .to_string(),
         ),
         DoctorCheckId::RequiredWorkflowFilesPresent => Some(format!(

--- a/cli/src/init.rs
+++ b/cli/src/init.rs
@@ -302,6 +302,9 @@ pub trait InitEnvironment {
     fn set_remote(&self, path: &Path, url: &str) -> Result<(), InitError>;
     /// Write a GitHub Actions workflow file under `.github/workflows/<name>`.
     fn write_workflow_file(&self, path: &Path, name: &str, content: &str) -> Result<(), InitError>;
+    /// Resolve the hooks directory via `git rev-parse --git-path hooks`.
+    /// Handles worktrees and `core.hooksPath` correctly.
+    fn git_hooks_path(&self, path: &Path) -> Result<PathBuf, InitError>;
 }
 
 // ---------------------------------------------------------------------------
@@ -440,6 +443,32 @@ impl InitEnvironment for HostInitEnvironment {
         fs::create_dir_all(&workflows_dir).map_err(InitError::Io)?;
         let file_path = workflows_dir.join(name);
         fs::write(file_path, content).map_err(InitError::Io)
+    }
+
+    fn git_hooks_path(&self, path: &Path) -> Result<PathBuf, InitError> {
+        let output = Command::new("git")
+            .args([
+                "-C",
+                &path.to_string_lossy(),
+                "rev-parse",
+                "--git-path",
+                "hooks",
+            ])
+            .output()
+            .map_err(InitError::Io)?;
+        if !output.status.success() {
+            return Err(InitError::git(
+                "git rev-parse --git-path hooks",
+                String::from_utf8_lossy(&output.stderr).trim(),
+            ));
+        }
+        let raw = PathBuf::from(String::from_utf8_lossy(&output.stdout).trim().to_string());
+        // git may return a relative path (e.g. `.git/hooks`) — resolve against the repo root.
+        if raw.is_absolute() {
+            Ok(raw)
+        } else {
+            Ok(path.join(raw))
+        }
     }
 }
 
@@ -702,7 +731,7 @@ fn do_init_steps(
     templates_written.push("prompts.yml".to_string());
 
     // Step 7: install git hook
-    let hooks_dir = request.repo_path.join(".git").join("hooks");
+    let hooks_dir = env.git_hooks_path(&request.repo_path)?;
     env.create_dir(&hooks_dir)?;
     let hook_path = hooks_dir.join("pre-push");
     env.write_file(&hook_path, PRE_PUSH_HOOK)?;

--- a/cli/tests/cli.rs
+++ b/cli/tests/cli.rs
@@ -145,7 +145,6 @@ fn doctor_command_prints_local_prerequisite_checks() {
     assert!(stdout.contains("gh-installed"));
     assert!(stdout.contains("codex-installed"));
     assert!(stdout.contains("github-remote-configured"));
-    assert!(stdout.contains("feature-binding-resolved"));
     assert!(stdout.contains("required-workflows-present"));
 }
 
@@ -244,7 +243,7 @@ fn status_command_reports_errors_outside_git_repository() {
 
 #[test]
 fn path_flag_long_routes_doctor_to_specified_directory() {
-    // A non-git dir will make github-remote-configured and feature-binding-resolved fail.
+    // A non-git dir will make github-remote-configured fail.
     // Crucially it must NOT make doctor itself fail to run (exit 0).
     let dir = temp_non_git_dir();
 

--- a/cli/tests/doctor.rs
+++ b/cli/tests/doctor.rs
@@ -3,7 +3,6 @@ use std::path::{Path, PathBuf};
 
 use calypso_cli::doctor::{
     DoctorCheckId, DoctorCheckScope, DoctorEnvironment, DoctorStatus, collect_doctor_report,
-    git_remote_output_has_github_remote,
 };
 
 #[derive(Default)]
@@ -12,8 +11,6 @@ struct FakeEnvironment {
     claude_reachable: bool,
     gh_authenticated: bool,
     github_remote_roots: BTreeSet<PathBuf>,
-    feature_binding_roots: BTreeSet<PathBuf>,
-    feature_binding_errors: BTreeMap<PathBuf, String>,
     missing_workflow_files: BTreeMap<PathBuf, Vec<String>>,
 }
 
@@ -30,17 +27,6 @@ impl FakeEnvironment {
 
     fn with_github_remote_root(mut self, root: &Path) -> Self {
         self.github_remote_roots.insert(root.to_path_buf());
-        self
-    }
-
-    fn with_feature_binding_root(mut self, root: &Path) -> Self {
-        self.feature_binding_roots.insert(root.to_path_buf());
-        self
-    }
-
-    fn with_feature_binding_error(mut self, root: &Path, detail: &str) -> Self {
-        self.feature_binding_errors
-            .insert(root.to_path_buf(), detail.to_string());
         self
     }
 
@@ -68,18 +54,6 @@ impl DoctorEnvironment for FakeEnvironment {
 
     fn has_github_remote(&self, repo_root: &Path) -> bool {
         self.github_remote_roots.contains(repo_root)
-    }
-
-    fn feature_binding_status(&self, repo_root: &Path) -> Result<(), String> {
-        if self.feature_binding_roots.contains(repo_root) {
-            return Ok(());
-        }
-
-        Err(self
-            .feature_binding_errors
-            .get(repo_root)
-            .cloned()
-            .unwrap_or_else(|| "branch is not mapped to an open pull request".to_string()))
     }
 
     fn missing_workflow_files(&self, repo_root: &Path) -> Vec<String> {
@@ -117,8 +91,7 @@ fn doctor_report_collects_expected_check_results() {
             .with_command("gh")
             .with_command("codex")
             .with_gh_authenticated(true)
-            .with_github_remote_root(repo_root)
-            .with_feature_binding_root(repo_root),
+            .with_github_remote_root(repo_root),
         repo_root,
     );
 
@@ -135,10 +108,6 @@ fn doctor_report_collects_expected_check_results() {
     );
     assert_eq!(
         statuses[&DoctorCheckId::GithubRemoteConfigured],
-        DoctorStatus::Passing
-    );
-    assert_eq!(
-        statuses[&DoctorCheckId::FeatureBindingResolved],
         DoctorStatus::Passing
     );
     assert_eq!(
@@ -166,10 +135,6 @@ fn doctor_report_marks_missing_dependencies_and_remote_checks_as_failing() {
         DoctorStatus::Failing
     );
     assert_eq!(
-        statuses[&DoctorCheckId::FeatureBindingResolved],
-        DoctorStatus::Failing
-    );
-    assert_eq!(
         statuses[&DoctorCheckId::RequiredWorkflowFilesPresent],
         DoctorStatus::Passing
     );
@@ -182,8 +147,7 @@ fn doctor_report_converts_check_results_into_builtin_evidence() {
         &FakeEnvironment::default()
             .with_command("gh")
             .with_gh_authenticated(true)
-            .with_github_remote_root(repo_root)
-            .with_feature_binding_root(repo_root),
+            .with_github_remote_root(repo_root),
         repo_root,
     );
 
@@ -206,30 +170,8 @@ fn doctor_report_converts_check_results_into_builtin_evidence() {
         Some(true)
     );
     assert_eq!(
-        evidence.result_for("builtin.doctor.feature_binding_resolved"),
-        Some(true)
-    );
-    assert_eq!(
         evidence.result_for("builtin.doctor.required_workflows_present"),
         Some(true)
-    );
-}
-
-#[test]
-fn doctor_report_marks_missing_feature_binding_as_failing() {
-    let repo_root = Path::new("/tmp/calypso");
-    let report = collect_doctor_report(
-        &FakeEnvironment::default().with_feature_binding_error(
-            repo_root,
-            "current branch is not mapped to an open pull request",
-        ),
-        repo_root,
-    );
-    let statuses = status_map(&report);
-
-    assert_eq!(
-        statuses[&DoctorCheckId::FeatureBindingResolved],
-        DoctorStatus::Failing
     );
 }
 
@@ -240,8 +182,7 @@ fn doctor_report_labels_external_auth_failures_separately_from_local_setup_failu
         &FakeEnvironment::default()
             .with_command("gh")
             .with_command("codex")
-            .with_github_remote_root(repo_root)
-            .with_feature_binding_root(repo_root),
+            .with_github_remote_root(repo_root),
         repo_root,
     );
 
@@ -250,27 +191,8 @@ fn doctor_report_labels_external_auth_failures_separately_from_local_setup_failu
         DoctorCheckScope::ExternalAuth
     );
     assert_eq!(
-        check_for(&report, DoctorCheckId::FeatureBindingResolved).scope,
+        check_for(&report, DoctorCheckId::GithubRemoteConfigured).scope,
         DoctorCheckScope::LocalConfiguration
-    );
-}
-
-#[test]
-fn doctor_report_exposes_actionable_remediation_in_the_result_model() {
-    let repo_root = Path::new("/tmp/calypso");
-    let report = collect_doctor_report(
-        &FakeEnvironment::default().with_feature_binding_error(
-            repo_root,
-            "current branch is not mapped to an open pull request",
-        ),
-        repo_root,
-    );
-
-    assert_eq!(
-        check_for(&report, DoctorCheckId::FeatureBindingResolved)
-            .remediation
-            .as_deref(),
-        Some("Ensure this worktree is on a feature branch with an open GitHub pull request.")
     );
 }
 
@@ -305,46 +227,6 @@ fn doctor_report_render_includes_actionable_fix_for_missing_workflows() {
     assert!(rendered.contains(
         "Add the missing workflow files under .github/workflows: release-cli.yml, rust-quality.yml"
     ));
-}
-
-#[test]
-fn doctor_report_render_includes_actionable_fix_for_missing_feature_binding() {
-    let repo_root = Path::new("/tmp/calypso");
-    let report = collect_doctor_report(
-        &FakeEnvironment::default().with_feature_binding_error(
-            repo_root,
-            "current branch is not mapped to an open pull request",
-        ),
-        repo_root,
-    );
-
-    let rendered = calypso_cli::doctor::render_doctor_report(&report);
-
-    assert!(rendered.contains("feature-binding-resolved"));
-    assert!(
-        rendered.contains(
-            "Ensure this worktree is on a feature branch with an open GitHub pull request."
-        )
-    );
-    assert!(rendered.contains("current branch is not mapped to an open pull request"));
-}
-
-#[test]
-fn git_remote_parser_detects_github_https_and_ssh_remotes() {
-    assert!(git_remote_output_has_github_remote(
-        "origin\thttps://github.com/acme/calypso.git (fetch)\n"
-    ));
-    assert!(git_remote_output_has_github_remote(
-        "origin\tgit@github.com:acme/calypso.git (push)\n"
-    ));
-}
-
-#[test]
-fn git_remote_parser_rejects_non_github_remotes() {
-    assert!(!git_remote_output_has_github_remote(
-        "origin\thttps://gitlab.com/acme/calypso.git (fetch)\n"
-    ));
-    assert!(!git_remote_output_has_github_remote(""));
 }
 
 #[test]
@@ -399,27 +281,6 @@ fn apply_fix_returns_instructions_for_manual_fix() {
         result,
         Ok("Install gh from https://cli.github.com".to_string())
     );
-}
-
-#[test]
-fn render_doctor_report_verbose_includes_remediation_text() {
-    use calypso_cli::doctor::render_doctor_report_verbose;
-
-    let repo_root = Path::new("/tmp/calypso");
-    let report = collect_doctor_report(
-        &FakeEnvironment::default().with_feature_binding_error(
-            repo_root,
-            "current branch is not mapped to an open pull request",
-        ),
-        repo_root,
-    );
-
-    let rendered = render_doctor_report_verbose(&report);
-
-    assert!(rendered.contains("Doctor checks (verbose)"));
-    assert!(rendered.contains("feature-binding-resolved"));
-    assert!(rendered.contains("Ensure this worktree is on a feature branch"));
-    assert!(rendered.contains("manual-fix:"));
 }
 
 #[test]

--- a/cli/tests/init.rs
+++ b/cli/tests/init.rs
@@ -186,6 +186,10 @@ impl InitEnvironment for FakeEnv {
             .push((name.to_string(), content.to_string()));
         Ok(())
     }
+
+    fn git_hooks_path(&self, path: &Path) -> Result<PathBuf, InitError> {
+        Ok(path.join(".git").join("hooks"))
+    }
 }
 
 // ── tests ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Removes `feature-binding-resolved` from doctor — worktree/PR binding validation belongs in the development state machine, not doctor
- Fixes `github-remote-configured` to use `gh repo view` instead of parsing `git remote -v` output — handles SSH host aliases correctly
- Fixes git hook installation in `init_repository` to resolve the hooks directory via `git rev-parse --git-path hooks` rather than hardcoding `.git/hooks` — works correctly for worktrees and `core.hooksPath`

## Key decisions

**`feature-binding-resolved` removed**: doctor checks environment prerequisites (tools installed, auth, remote configured, workflows present). Whether the current worktree maps to an open PR is a development workflow concern — the dev state machine will enforce this when it runs.

**`gh repo view` for remote detection**: the previous check parsed `git remote -v` and matched against literal `github.com` strings, failing for SSH aliases (e.g. `github-lucky:org/repo.git`). `gh repo view` delegates resolution to gh itself, which handles aliases, SSH config, and HTTPS remotes uniformly.

**`git rev-parse --git-path hooks`**: resolves the hooks path as git sees it, respecting `core.hooksPath` and returning the correct linked worktree path rather than `.git/hooks` in the worktree's `.git` file.

## Test plan

- [x] All 33 tests pass (`cargo test`)
- [x] `calypso doctor` from main branch no longer shows `feature-binding-resolved` as failing
- [x] `calypso --path ~/calypso/ doctor` shows green for `github-remote-configured` with SSH alias remote