### PR TITLE
feat: doctor --json, state status, and agents subcommands

### DIFF
--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -3,12 +3,18 @@ use std::process::Command;
 
 use serde::Deserialize;
 
-use crate::doctor::{HostDoctorEnvironment, collect_doctor_report, render_doctor_report};
+use crate::doctor::{
+    DoctorReport, DoctorStatus, HostDoctorEnvironment, collect_doctor_report, render_doctor_report,
+};
 use crate::github::{HostGithubEnvironment, collect_github_report};
 use crate::policy::{HostPolicyEnvironment, collect_policy_evidence};
+use crate::report::{
+    AgentJsonSession, AgentsJsonReport, DoctorJsonCheck, DoctorJsonReport, DoctorJsonSummary,
+    StateJsonGate, StateJsonGateGroup, StateStatusJsonReport,
+};
 use crate::state::{
-    BuiltinEvidence, EvidenceStatus, FeatureState, GateStatus, GithubMergeability,
-    GithubReviewStatus, PullRequestChecklistItem, PullRequestRef,
+    AgentSession, AgentSessionStatus, BuiltinEvidence, EvidenceStatus, FeatureState, GateStatus,
+    GithubMergeability, GithubReviewStatus, PullRequestChecklistItem, PullRequestRef,
 };
 use crate::template::load_embedded_template_set;
 
@@ -284,4 +290,264 @@ fn evidence_status_label(status: &EvidenceStatus) -> &'static str {
         EvidenceStatus::Pending => "pending",
         EvidenceStatus::Manual => "manual",
     }
+}
+
+// ---------------------------------------------------------------------------
+// Feature 1 — doctor --json
+// ---------------------------------------------------------------------------
+
+/// Build a `DoctorJsonReport` from a `DoctorReport`.
+pub fn doctor_json_report(report: &DoctorReport) -> DoctorJsonReport {
+    let checks: Vec<DoctorJsonCheck> = report
+        .checks
+        .iter()
+        .map(|check| DoctorJsonCheck {
+            id: check.id.label().to_string(),
+            status: if check.status == DoctorStatus::Passing {
+                "passing"
+            } else {
+                "failing"
+            },
+            detail: check.detail.clone(),
+            remediation: check.remediation.clone(),
+            has_auto_fix: check.fix.as_ref().is_some_and(|f| f.is_automatic()),
+        })
+        .collect();
+
+    let total = checks.len();
+    let passing = checks.iter().filter(|c| c.status == "passing").count();
+    let failing = total - passing;
+
+    DoctorJsonReport {
+        checks,
+        summary: DoctorJsonSummary {
+            total,
+            passing,
+            failing,
+        },
+    }
+}
+
+/// Run the doctor check and return the JSON report as a pretty-printed string.
+/// Returns `Ok(json)` when all checks pass, `Err(json)` when any fail.
+pub fn run_doctor_json(cwd: &Path) -> Result<String, String> {
+    let repo_root = resolve_repo_root(cwd).unwrap_or_else(|| cwd.to_path_buf());
+    let report = collect_doctor_report(&HostDoctorEnvironment, &repo_root);
+    let json_report = doctor_json_report(&report);
+    let json = serde_json::to_string_pretty(&json_report).expect("DoctorJsonReport must serialize");
+    if json_report.summary.failing == 0 {
+        Ok(json)
+    } else {
+        Err(json)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Feature 2 — state status (plain text and --json)
+// ---------------------------------------------------------------------------
+
+fn gate_status_str(status: &GateStatus) -> &'static str {
+    match status {
+        GateStatus::Passing => "passing",
+        GateStatus::Failing => "failing",
+        GateStatus::Pending => "pending",
+        GateStatus::Manual => "manual",
+    }
+}
+
+/// Build a `StateStatusJsonReport` from a loaded `FeatureState`.
+pub fn state_status_json_report(feature: &FeatureState) -> StateStatusJsonReport {
+    let gate_groups = feature
+        .gate_groups
+        .iter()
+        .map(|group| {
+            let rollup = group.rollup();
+            let group_status = match rollup.status {
+                crate::state::GateGroupStatus::Passing => "passing",
+                crate::state::GateGroupStatus::Pending => "pending",
+                crate::state::GateGroupStatus::Manual => "manual",
+                crate::state::GateGroupStatus::Blocked => "failing",
+            };
+            StateJsonGateGroup {
+                id: group.id.clone(),
+                label: group.label.clone(),
+                status: group_status,
+                gates: group
+                    .gates
+                    .iter()
+                    .map(|gate| StateJsonGate {
+                        id: gate.id.clone(),
+                        label: gate.label.clone(),
+                        status: gate_status_str(&gate.status),
+                    })
+                    .collect(),
+            }
+        })
+        .collect();
+
+    let pr_number = if feature.pull_request.number == 0 {
+        None
+    } else {
+        Some(feature.pull_request.number)
+    };
+
+    StateStatusJsonReport {
+        feature_id: feature.feature_id.clone(),
+        branch: feature.branch.clone(),
+        pr_number,
+        workflow_state: feature.workflow_state.as_str().to_string(),
+        gate_groups,
+        blocking_gate_ids: feature.blocking_gate_ids(),
+        active_session_count: feature.active_sessions.len(),
+    }
+}
+
+/// Load state from `.calypso/state.json` and return the JSON report.
+/// Returns `Ok(json)` on success, `Err(message)` when the file cannot be loaded.
+pub fn run_state_status_json(cwd: &Path) -> Result<String, String> {
+    let state_path = cwd.join(".calypso").join("state.json");
+    let state =
+        crate::state::RepositoryState::load_from_path(&state_path).map_err(|e| e.to_string())?;
+    let json_report = state_status_json_report(&state.current_feature);
+    serde_json::to_string_pretty(&json_report).map_err(|e| format!("serialization error: {e}"))
+}
+
+/// Render a human-readable summary of the feature state.
+pub fn render_state_status(feature: &FeatureState) -> String {
+    let mut lines = Vec::new();
+
+    lines.push(format!("feature: {}", feature.feature_id));
+
+    let pr_part = if feature.pull_request.number != 0 {
+        format!("  PR: #{}", feature.pull_request.number)
+    } else {
+        String::new()
+    };
+    lines.push(format!("branch:  {}{}", feature.branch, pr_part));
+    lines.push(format!("state:   {}", feature.workflow_state.as_str()));
+
+    if !feature.gate_groups.is_empty() {
+        lines.push(String::new());
+        lines.push("  Gates".to_string());
+        lines.push(format!("  {}", "─".repeat(33)));
+        for group in &feature.gate_groups {
+            let rollup = group.rollup();
+            let blocking_count = rollup.blocking_gate_ids.len();
+            let group_marker = if blocking_count == 0 { "✓" } else { "✗" };
+            let blocking_str = if blocking_count > 0 {
+                format!("  {} blocking", blocking_count)
+            } else {
+                String::new()
+            };
+            lines.push(format!(
+                "  {} {}{}",
+                group_marker, group.label, blocking_str
+            ));
+            for gate in &group.gates {
+                let gate_marker = if gate.status == GateStatus::Passing {
+                    "✓"
+                } else {
+                    "✗"
+                };
+                lines.push(format!("    {} {}", gate_marker, gate.label));
+            }
+        }
+    }
+
+    lines.join("\n")
+}
+
+/// Load state from `.calypso/state.json` and return a plain-text summary.
+pub fn run_state_status_plain(cwd: &Path) -> Result<String, String> {
+    let state_path = cwd.join(".calypso").join("state.json");
+    let state =
+        crate::state::RepositoryState::load_from_path(&state_path).map_err(|e| e.to_string())?;
+    Ok(render_state_status(&state.current_feature))
+}
+
+// ---------------------------------------------------------------------------
+// Feature 3 — agents (plain text and --json)
+// ---------------------------------------------------------------------------
+
+fn agent_status_str(status: &AgentSessionStatus) -> &'static str {
+    match status {
+        AgentSessionStatus::Running => "running",
+        AgentSessionStatus::WaitingForHuman => "waiting-for-human",
+        AgentSessionStatus::Completed => "completed",
+        AgentSessionStatus::Failed => "failed",
+        AgentSessionStatus::Aborted => "aborted",
+    }
+}
+
+/// Build an `AgentsJsonReport` from a `FeatureState`.
+pub fn agents_json_report(feature: &FeatureState) -> AgentsJsonReport {
+    let sessions = feature
+        .active_sessions
+        .iter()
+        .map(|session| AgentJsonSession {
+            session_id: session.session_id.clone(),
+            role: session.role.clone(),
+            status: agent_status_str(&session.status).to_string(),
+            output: session.output.iter().map(|o| o.text.clone()).collect(),
+            pending_follow_ups: session.pending_follow_ups.clone(),
+        })
+        .collect();
+
+    AgentsJsonReport {
+        feature_id: feature.feature_id.clone(),
+        sessions,
+    }
+}
+
+/// Load state from `.calypso/state.json` and return the agents JSON report.
+pub fn run_agents_json(cwd: &Path) -> Result<String, String> {
+    let state_path = cwd.join(".calypso").join("state.json");
+    let state =
+        crate::state::RepositoryState::load_from_path(&state_path).map_err(|e| e.to_string())?;
+    let json_report = agents_json_report(&state.current_feature);
+    serde_json::to_string_pretty(&json_report).map_err(|e| format!("serialization error: {e}"))
+}
+
+/// Render a human-readable agents status from a session list.
+pub fn render_agents(feature: &FeatureState) -> String {
+    let mut lines = Vec::new();
+    lines.push(format!("Active sessions for {}", feature.feature_id));
+    lines.push("─".repeat(42));
+
+    if feature.active_sessions.is_empty() {
+        lines.push("  (no active sessions)".to_string());
+    } else {
+        for session in &feature.active_sessions {
+            let (marker, status_str) = session_display_parts(session);
+            lines.push(format!(
+                "{} {}  [{}]  {}",
+                marker, session.role, session.session_id, status_str
+            ));
+            for line in &session.output {
+                for text_line in line.text.lines() {
+                    lines.push(format!("  {text_line}"));
+                }
+            }
+        }
+    }
+
+    lines.join("\n")
+}
+
+fn session_display_parts(session: &AgentSession) -> (&'static str, &'static str) {
+    match session.status {
+        AgentSessionStatus::Running => ("▶", "running"),
+        AgentSessionStatus::WaitingForHuman => ("⏸", "waiting-for-human"),
+        AgentSessionStatus::Completed => ("✓", "completed"),
+        AgentSessionStatus::Failed => ("✗", "failed"),
+        AgentSessionStatus::Aborted => ("✗", "aborted"),
+    }
+}
+
+/// Load state from `.calypso/state.json` and return a plain-text agents summary.
+pub fn run_agents_plain(cwd: &Path) -> Result<String, String> {
+    let state_path = cwd.join(".calypso").join("state.json");
+    let state =
+        crate::state::RepositoryState::load_from_path(&state_path).map_err(|e| e.to_string())?;
+    Ok(render_agents(&state.current_feature))
 }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -11,6 +11,7 @@ pub mod github;
 pub mod init;
 pub mod policy;
 pub mod pr_checklist;
+pub mod report;
 pub mod runtime;
 pub mod state;
 pub mod telemetry;
@@ -50,12 +51,17 @@ Commands:
   (none)              Drive the state machine for the project directory
   --step              Drive the state machine one step at a time
   doctor              Check local prerequisites and environment
+  doctor --json       Output doctor results as JSON (exit 1 if any failing)
   doctor --fix <id>   Apply an available fix for a doctor check
   status              Render the feature status for the project directory
+  state status        Show a human-readable summary of .calypso/state.json
+  state status --json Output state status as JSON
+  state show          Print the current state file as raw JSON
+  agents              Show active agent sessions
+  agents --json       Output agent sessions as JSON
   watch               Open the interactive operator surface (live TUI)
   init                Initialise a repository for Calypso
   init --reinit       Re-initialise an already-initialised repository
-  state show          Print the current state file as JSON
   feature-start <id> --worktree-base <path>
                       Create a feature branch, worktree, draft PR, and state file
   template validate   Validate the local workflow template

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,4 +1,7 @@
-use calypso_cli::app::{run_doctor, run_status};
+use calypso_cli::app::{
+    run_agents_json, run_agents_plain, run_doctor, run_doctor_json, run_state_status_json,
+    run_state_status_plain, run_status,
+};
 use calypso_cli::doctor::{DoctorFix, DoctorStatus, apply_fix, collect_doctor_report};
 use calypso_cli::execution::{ExecutionConfig, ExecutionOutcome, run_supervised_session};
 use calypso_cli::feature_start::{FeatureStartRequest, run_feature_start};
@@ -39,6 +42,13 @@ fn main() {
         [command] if command == "doctor" => {
             println!("{}", run_doctor(&cwd));
         }
+        [command, flag] if command == "doctor" && flag == "--json" => match run_doctor_json(&cwd) {
+            Ok(json) => println!("{json}"),
+            Err(json) => {
+                println!("{json}");
+                std::process::exit(1);
+            }
+        },
         [command, flag, check_id] if command == "doctor" && flag == "--fix" => {
             run_doctor_fix(check_id, &cwd);
         }
@@ -77,6 +87,42 @@ fn main() {
                 }
             }
         }
+        // calypso state status [--json]
+        [command, subcommand] if command == "state" && subcommand == "status" => {
+            match run_state_status_plain(&cwd) {
+                Ok(output) => println!("{output}"),
+                Err(error) => {
+                    eprintln!("state status error: {error}");
+                    std::process::exit(1);
+                }
+            }
+        }
+        [command, subcommand, flag]
+            if command == "state" && subcommand == "status" && flag == "--json" =>
+        {
+            match run_state_status_json(&cwd) {
+                Ok(json) => println!("{json}"),
+                Err(error) => {
+                    eprintln!("state status error: {error}");
+                    std::process::exit(1);
+                }
+            }
+        }
+        // calypso agents [--json]
+        [command] if command == "agents" => match run_agents_plain(&cwd) {
+            Ok(output) => println!("{output}"),
+            Err(error) => {
+                eprintln!("agents error: {error}");
+                std::process::exit(1);
+            }
+        },
+        [command, flag] if command == "agents" && flag == "--json" => match run_agents_json(&cwd) {
+            Ok(json) => println!("{json}"),
+            Err(error) => {
+                eprintln!("agents error: {error}");
+                std::process::exit(1);
+            }
+        },
         [command, feature_id, flag, worktree_base]
             if command == "feature-start" && flag == "--worktree-base" =>
         {

--- a/cli/src/report.rs
+++ b/cli/src/report.rs
@@ -1,0 +1,80 @@
+//! Thin output structs used by `--json` flags across CLI subcommands.
+//!
+//! All types derive `Serialize`; none carry business logic.
+
+use serde::Serialize;
+
+// ---------------------------------------------------------------------------
+// Feature 1 — doctor --json
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct DoctorJsonReport {
+    pub checks: Vec<DoctorJsonCheck>,
+    pub summary: DoctorJsonSummary,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct DoctorJsonCheck {
+    pub id: String,
+    pub status: &'static str,
+    pub detail: Option<String>,
+    pub remediation: Option<String>,
+    pub has_auto_fix: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct DoctorJsonSummary {
+    pub total: usize,
+    pub passing: usize,
+    pub failing: usize,
+}
+
+// ---------------------------------------------------------------------------
+// Feature 2 — state status --json
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct StateStatusJsonReport {
+    pub feature_id: String,
+    pub branch: String,
+    pub pr_number: Option<u64>,
+    pub workflow_state: String,
+    pub gate_groups: Vec<StateJsonGateGroup>,
+    pub blocking_gate_ids: Vec<String>,
+    pub active_session_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct StateJsonGateGroup {
+    pub id: String,
+    pub label: String,
+    pub status: &'static str,
+    pub gates: Vec<StateJsonGate>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct StateJsonGate {
+    pub id: String,
+    pub label: String,
+    pub status: &'static str,
+}
+
+// ---------------------------------------------------------------------------
+// Feature 3 — agents --json
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct AgentsJsonReport {
+    pub feature_id: String,
+    pub sessions: Vec<AgentJsonSession>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct AgentJsonSession {
+    pub session_id: String,
+    pub role: String,
+    pub status: String,
+    pub output: Vec<String>,
+    pub pending_follow_ups: Vec<String>,
+}

--- a/cli/tests/report.rs
+++ b/cli/tests/report.rs
@@ -1,0 +1,383 @@
+//! Integration tests for the JSON report shapes produced by the three new CLI features:
+//!   1. `calypso doctor --json`  (Feature 1)
+//!   2. `calypso state status --json`  (Feature 2)
+//!   3. `calypso agents --json`  (Feature 3)
+
+use calypso_cli::app::{agents_json_report, doctor_json_report, state_status_json_report};
+use calypso_cli::doctor::{
+    DoctorCheck, DoctorCheckId, DoctorCheckScope, DoctorReport, DoctorStatus,
+};
+use calypso_cli::state::{
+    AgentSession, AgentSessionStatus, FeatureState, Gate, GateGroup, GateStatus, PullRequestRef,
+    SessionOutput, SessionOutputStream, WorkflowState,
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn passing_check(id: DoctorCheckId) -> DoctorCheck {
+    DoctorCheck {
+        id,
+        scope: DoctorCheckScope::LocalConfiguration,
+        status: DoctorStatus::Passing,
+        detail: None,
+        remediation: None,
+        fix: None,
+    }
+}
+
+fn failing_check(
+    id: DoctorCheckId,
+    detail: Option<String>,
+    remediation: Option<String>,
+) -> DoctorCheck {
+    DoctorCheck {
+        id,
+        scope: DoctorCheckScope::LocalConfiguration,
+        status: DoctorStatus::Failing,
+        detail,
+        remediation,
+        fix: None,
+    }
+}
+
+fn minimal_feature_state() -> FeatureState {
+    FeatureState {
+        feature_id: "feat-login-oauth".to_string(),
+        branch: "feat/login-oauth".to_string(),
+        worktree_path: "/tmp/worktree".to_string(),
+        pull_request: PullRequestRef {
+            number: 42,
+            url: "https://github.com/example/repo/pull/42".to_string(),
+        },
+        github_snapshot: None,
+        github_error: None,
+        workflow_state: WorkflowState::Implementation,
+        gate_groups: vec![
+            GateGroup {
+                id: "spec".to_string(),
+                label: "Specification".to_string(),
+                gates: vec![Gate {
+                    id: "spec.canonicalized".to_string(),
+                    label: "PR canonicalized".to_string(),
+                    task: "builtin.github.pr_canonicalized".to_string(),
+                    status: GateStatus::Passing,
+                }],
+            },
+            GateGroup {
+                id: "validation".to_string(),
+                label: "Validation".to_string(),
+                gates: vec![Gate {
+                    id: "validation.rust_quality".to_string(),
+                    label: "Rust quality green".to_string(),
+                    task: "builtin.doctor.rust_quality".to_string(),
+                    status: GateStatus::Failing,
+                }],
+            },
+        ],
+        active_sessions: vec![AgentSession {
+            role: "engineer".to_string(),
+            session_id: "session_01".to_string(),
+            provider_session_id: None,
+            status: AgentSessionStatus::Running,
+            output: vec![SessionOutput {
+                stream: SessionOutputStream::Stdout,
+                text: "Inspecting branch state…".to_string(),
+            }],
+            pending_follow_ups: vec![],
+            terminal_outcome: None,
+        }],
+        feature_type: calypso_cli::state::FeatureType::Feat,
+        roles: vec![],
+        scheduling: calypso_cli::state::SchedulingMeta::default(),
+        artifact_refs: vec![],
+        transcript_refs: vec![],
+        clarification_history: vec![],
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Feature 1 — doctor --json
+// ---------------------------------------------------------------------------
+
+#[test]
+fn doctor_json_all_passing_has_correct_summary() {
+    let report = DoctorReport {
+        checks: vec![
+            passing_check(DoctorCheckId::GitInitialized),
+            passing_check(DoctorCheckId::GhInstalled),
+            passing_check(DoctorCheckId::ClaudeInstalled),
+        ],
+    };
+
+    let json_report = doctor_json_report(&report);
+
+    assert_eq!(json_report.summary.total, 3);
+    assert_eq!(json_report.summary.passing, 3);
+    assert_eq!(json_report.summary.failing, 0);
+}
+
+#[test]
+fn doctor_json_failing_check_counted_in_summary() {
+    let report = DoctorReport {
+        checks: vec![
+            passing_check(DoctorCheckId::GitInitialized),
+            failing_check(
+                DoctorCheckId::GhInstalled,
+                Some("gh not found".to_string()),
+                Some("Install gh CLI".to_string()),
+            ),
+        ],
+    };
+
+    let json_report = doctor_json_report(&report);
+
+    assert_eq!(json_report.summary.total, 2);
+    assert_eq!(json_report.summary.passing, 1);
+    assert_eq!(json_report.summary.failing, 1);
+}
+
+#[test]
+fn doctor_json_check_fields_match_source() {
+    let report = DoctorReport {
+        checks: vec![failing_check(
+            DoctorCheckId::GhInstalled,
+            Some("not on PATH".to_string()),
+            Some("Install from https://cli.github.com".to_string()),
+        )],
+    };
+
+    let json_report = doctor_json_report(&report);
+
+    assert_eq!(json_report.checks.len(), 1);
+    let check = &json_report.checks[0];
+    assert_eq!(check.id, "gh-installed");
+    assert_eq!(check.status, "failing");
+    assert_eq!(check.detail.as_deref(), Some("not on PATH"));
+    assert_eq!(
+        check.remediation.as_deref(),
+        Some("Install from https://cli.github.com")
+    );
+    assert!(
+        !check.has_auto_fix,
+        "manual remediation should not be auto-fix"
+    );
+}
+
+#[test]
+fn doctor_json_serializes_to_valid_json() {
+    let report = DoctorReport {
+        checks: vec![passing_check(DoctorCheckId::GitInitialized)],
+    };
+
+    let json_report = doctor_json_report(&report);
+    let json = serde_json::to_string_pretty(&json_report).expect("must serialize");
+
+    // Round-trip: verify expected top-level keys are present.
+    let value: serde_json::Value = serde_json::from_str(&json).expect("must be valid JSON");
+    assert!(value.get("checks").is_some(), "must have 'checks' key");
+    assert!(value.get("summary").is_some(), "must have 'summary' key");
+    let summary = &value["summary"];
+    assert!(summary.get("total").is_some());
+    assert!(summary.get("passing").is_some());
+    assert!(summary.get("failing").is_some());
+}
+
+#[test]
+fn doctor_json_passing_check_has_null_detail_and_remediation() {
+    let report = DoctorReport {
+        checks: vec![passing_check(DoctorCheckId::GitInitialized)],
+    };
+
+    let json_report = doctor_json_report(&report);
+    let check = &json_report.checks[0];
+
+    assert!(check.detail.is_none());
+    assert!(check.remediation.is_none());
+    assert_eq!(check.status, "passing");
+}
+
+// ---------------------------------------------------------------------------
+// Feature 2 — state status --json
+// ---------------------------------------------------------------------------
+
+#[test]
+fn state_status_json_basic_fields() {
+    let feature = minimal_feature_state();
+    let report = state_status_json_report(&feature);
+
+    assert_eq!(report.feature_id, "feat-login-oauth");
+    assert_eq!(report.branch, "feat/login-oauth");
+    assert_eq!(report.pr_number, Some(42));
+    assert_eq!(report.workflow_state, "implementation");
+    assert_eq!(report.active_session_count, 1);
+}
+
+#[test]
+fn state_status_json_blocking_gate_ids_populated() {
+    let feature = minimal_feature_state();
+    let report = state_status_json_report(&feature);
+
+    assert!(
+        report
+            .blocking_gate_ids
+            .contains(&"validation.rust_quality".to_string()),
+        "failing gate should appear in blocking_gate_ids"
+    );
+}
+
+#[test]
+fn state_status_json_gate_groups_shape() {
+    let feature = minimal_feature_state();
+    let report = state_status_json_report(&feature);
+
+    assert_eq!(report.gate_groups.len(), 2);
+
+    let spec_group = &report.gate_groups[0];
+    assert_eq!(spec_group.id, "spec");
+    assert_eq!(spec_group.status, "passing");
+    assert_eq!(spec_group.gates.len(), 1);
+    assert_eq!(spec_group.gates[0].status, "passing");
+
+    let validation_group = &report.gate_groups[1];
+    assert_eq!(validation_group.id, "validation");
+    assert_eq!(validation_group.status, "failing");
+    assert_eq!(validation_group.gates[0].status, "failing");
+}
+
+#[test]
+fn state_status_json_no_pr_yields_null_pr_number() {
+    let mut feature = minimal_feature_state();
+    feature.pull_request = PullRequestRef {
+        number: 0,
+        url: String::new(),
+    };
+
+    let report = state_status_json_report(&feature);
+    assert!(report.pr_number.is_none());
+}
+
+#[test]
+fn state_status_json_serializes_to_valid_json() {
+    let feature = minimal_feature_state();
+    let report = state_status_json_report(&feature);
+    let json = serde_json::to_string_pretty(&report).expect("must serialize");
+
+    let value: serde_json::Value = serde_json::from_str(&json).expect("must be valid JSON");
+    assert!(value.get("feature_id").is_some());
+    assert!(value.get("branch").is_some());
+    assert!(value.get("workflow_state").is_some());
+    assert!(value.get("gate_groups").is_some());
+    assert!(value.get("blocking_gate_ids").is_some());
+    assert!(value.get("active_session_count").is_some());
+}
+
+#[test]
+fn state_status_json_missing_state_file_returns_error() {
+    let tmp = std::env::temp_dir().join("calypso-test-no-state-file");
+    // Ensure the directory does NOT have a state file.
+    let _ = std::fs::remove_dir_all(&tmp);
+
+    let result = calypso_cli::app::run_state_status_json(&tmp);
+    assert!(
+        result.is_err(),
+        "missing state file should produce an error"
+    );
+    let msg = result.unwrap_err();
+    assert!(
+        msg.contains("state I/O error") || msg.contains("os error") || !msg.is_empty(),
+        "error message should be non-empty: {msg}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Feature 3 — agents --json
+// ---------------------------------------------------------------------------
+
+#[test]
+fn agents_json_basic_fields() {
+    let feature = minimal_feature_state();
+    let report = agents_json_report(&feature);
+
+    assert_eq!(report.feature_id, "feat-login-oauth");
+    assert_eq!(report.sessions.len(), 1);
+
+    let session = &report.sessions[0];
+    assert_eq!(session.session_id, "session_01");
+    assert_eq!(session.role, "engineer");
+    assert_eq!(session.status, "running");
+    assert_eq!(session.output, vec!["Inspecting branch state…"]);
+    assert!(session.pending_follow_ups.is_empty());
+}
+
+#[test]
+fn agents_json_empty_sessions() {
+    let mut feature = minimal_feature_state();
+    feature.active_sessions = vec![];
+
+    let report = agents_json_report(&feature);
+    assert!(report.sessions.is_empty());
+}
+
+#[test]
+fn agents_json_serializes_to_valid_json() {
+    let feature = minimal_feature_state();
+    let report = agents_json_report(&feature);
+    let json = serde_json::to_string_pretty(&report).expect("must serialize");
+
+    let value: serde_json::Value = serde_json::from_str(&json).expect("must be valid JSON");
+    assert!(value.get("feature_id").is_some());
+    assert!(value.get("sessions").is_some());
+
+    let sessions = value["sessions"]
+        .as_array()
+        .expect("sessions must be array");
+    assert_eq!(sessions.len(), 1);
+    let s = &sessions[0];
+    assert!(s.get("session_id").is_some());
+    assert!(s.get("role").is_some());
+    assert!(s.get("status").is_some());
+    assert!(s.get("output").is_some());
+    assert!(s.get("pending_follow_ups").is_some());
+}
+
+#[test]
+fn agents_json_missing_state_file_returns_error() {
+    let tmp = std::env::temp_dir().join("calypso-test-no-agents-state");
+    let _ = std::fs::remove_dir_all(&tmp);
+
+    let result = calypso_cli::app::run_agents_json(&tmp);
+    assert!(
+        result.is_err(),
+        "missing state file should produce an error"
+    );
+}
+
+#[test]
+fn agents_json_completed_session_status_string() {
+    let mut feature = minimal_feature_state();
+    feature.active_sessions[0].status = AgentSessionStatus::Completed;
+
+    let report = agents_json_report(&feature);
+    assert_eq!(report.sessions[0].status, "completed");
+}
+
+#[test]
+fn agents_json_multiple_sessions_all_present() {
+    let mut feature = minimal_feature_state();
+    feature.active_sessions.push(AgentSession {
+        role: "reviewer".to_string(),
+        session_id: "session_02".to_string(),
+        provider_session_id: None,
+        status: AgentSessionStatus::Completed,
+        output: vec![],
+        pending_follow_ups: vec![],
+        terminal_outcome: None,
+    });
+
+    let report = agents_json_report(&feature);
+    assert_eq!(report.sessions.len(), 2);
+    assert_eq!(report.sessions[1].role, "reviewer");
+    assert_eq!(report.sessions[1].status, "completed");
+}


### PR DESCRIPTION
## Summary

- Adds `calypso doctor --json` (#108): structured JSON output for all doctor checks with a per-check breakdown and a `{ total, passing, failing }` summary; exits 1 when any check is failing, 0 when all pass. Plain `calypso doctor` behaviour is unchanged.
- Adds `calypso state status [--json]` (#109): loads `.calypso/state.json` from the project directory and renders either a compact human-readable gate summary or a machine-readable JSON report matching the specified output shape.
- Adds `calypso agents [--json]` (#110): shows active session status (role, session ID, status, output lines, pending follow-ups) from the state file, in both human and JSON form.

Closes #108, #109, #110.

## Key decisions

- Thin output structs live in a new `cli/src/report.rs` module, each `#[derive(Serialize)]`; no business logic in the report layer.
- `run_doctor_json` returns `Ok(json)` / `Err(json)` so `main.rs` can print the JSON unconditionally and set the exit code only via the result variant — keeping the output identical for both success and failure paths.
- `pr_number` serializes as `null` when the PR number is 0 (no PR yet), matching the specified output shape.
- Agent `output` in JSON is a flat `Vec<String>` (one entry per `SessionOutput.text`), consistent with the spec.
- Help text updated to document all new subcommands.

## Test plan

- [x] `cargo clippy -- -D warnings` passes with zero warnings
- [x] `cargo fmt -- --check` passes (no formatting changes needed after fmt)
- [x] `cargo test` passes — all 17 new tests in `cli/tests/report.rs` plus all pre-existing tests green
- [x] Doctor JSON summary counts match check list length and pass/fail split
- [x] State status JSON `blocking_gate_ids` contains all non-passing gate IDs
- [x] State status JSON `pr_number` is `null` when PR number is 0
- [x] Missing state file returns `Err` with non-empty message for both `state status` and `agents`
- [x] Agents JSON `status` strings match `AgentSessionStatus` variants
- [x] All three JSON reports round-trip through `serde_json::from_str` without error