### PR TITLE
test: state machine autopilot and agent status reporting tests

### DIFF
--- a/cli/src/driver.rs
+++ b/cli/src/driver.rs
@@ -8,10 +8,41 @@
 //! q to quit).
 
 use std::path::Path;
+use std::sync::Arc;
 
-use crate::execution::{ExecutionConfig, ExecutionOutcome, run_supervised_session};
+use crate::execution::{ExecutionConfig, ExecutionError, ExecutionOutcome, run_supervised_session};
 use crate::state::{RepositoryState, WorkflowState};
 use crate::template::{StateDefinition, StepType, TemplateSet};
+
+// ── SessionExecutor trait ─────────────────────────────────────────────────────
+
+/// Abstraction over the supervised-session execution layer.
+///
+/// The real implementation calls Claude via `run_supervised_session`.
+/// Tests inject a `PhonyExecutor` that returns pre-canned outcomes without
+/// spawning any external process.
+pub trait SessionExecutor: Send + Sync {
+    fn run(
+        &self,
+        state_path: &Path,
+        role: &str,
+        config: &ExecutionConfig,
+    ) -> Result<ExecutionOutcome, ExecutionError>;
+}
+
+/// Production executor — delegates to `run_supervised_session`.
+pub struct RealExecutor;
+
+impl SessionExecutor for RealExecutor {
+    fn run(
+        &self,
+        state_path: &Path,
+        role: &str,
+        config: &ExecutionConfig,
+    ) -> Result<ExecutionOutcome, ExecutionError> {
+        run_supervised_session(state_path, role, config)
+    }
+}
 
 /// Whether the driver runs all steps automatically or waits for a keypress between steps.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -43,6 +74,8 @@ pub struct StateMachineDriver {
     pub state_path: std::path::PathBuf,
     pub template: TemplateSet,
     pub config: ExecutionConfig,
+    /// Pluggable session executor. `None` uses `RealExecutor` (default).
+    pub executor: Option<Arc<dyn SessionExecutor>>,
 }
 
 impl StateMachineDriver {
@@ -90,7 +123,13 @@ impl StateMachineDriver {
             })
             .unwrap_or_else(|| state_name.to_string());
 
-        match run_supervised_session(&self.state_path, &role, &self.config) {
+        let result = if let Some(exec) = &self.executor {
+            exec.run(&self.state_path, &role, &self.config)
+        } else {
+            run_supervised_session(&self.state_path, &role, &self.config)
+        };
+
+        match result {
             Ok(outcome) => match outcome {
                 ExecutionOutcome::Ok { advanced_to, .. } => advanced_to
                     .map(DriverStepResult::Advanced)

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -352,6 +352,7 @@ fn run_state_machine_auto(state_path: &std::path::Path) {
         state_path: state_path.to_path_buf(),
         template,
         config: ExecutionConfig::default(),
+        executor: None,
     };
 
     let results = driver.run_auto();
@@ -395,6 +396,7 @@ fn run_state_machine_step(state_path: &std::path::Path) {
         state_path: state_path.to_path_buf(),
         template,
         config: ExecutionConfig::default(),
+        executor: None,
     };
 
     loop {

--- a/cli/tests/agent_reporting.rs
+++ b/cli/tests/agent_reporting.rs
@@ -1,0 +1,443 @@
+//! Tests for agent status reporting — session builder helpers, text rendering,
+//! and state file round-trips.
+//!
+//! These tests exercise the `OperatorSurface` rendering functions to assert
+//! that session status icons, output lines, and pending clarifications appear
+//! correctly in the rendered output.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use calypso_cli::state::{
+    AgentSession, AgentSessionStatus, AgentTerminalOutcome, ClarificationEntry, FeatureState,
+    FeatureType, Gate, GateGroup, GateStatus, PullRequestRef, RepositoryState, SchedulingMeta,
+    SessionOutput, SessionOutputStream, WorkflowState,
+};
+use calypso_cli::tui::OperatorSurface;
+
+// ── Session builder helpers ───────────────────────────────────────────────────
+
+fn running_session(role: &str, output_lines: &[&str]) -> AgentSession {
+    AgentSession {
+        role: role.to_string(),
+        session_id: format!("{role}-session"),
+        provider_session_id: None,
+        status: AgentSessionStatus::Running,
+        output: output_lines
+            .iter()
+            .map(|line| SessionOutput {
+                stream: SessionOutputStream::Stdout,
+                text: line.to_string(),
+            })
+            .collect(),
+        pending_follow_ups: vec![],
+        terminal_outcome: None,
+    }
+}
+
+fn completed_session(role: &str) -> AgentSession {
+    AgentSession {
+        role: role.to_string(),
+        session_id: format!("{role}-session"),
+        provider_session_id: None,
+        status: AgentSessionStatus::Completed,
+        output: vec![],
+        pending_follow_ups: vec![],
+        terminal_outcome: Some(AgentTerminalOutcome::Ok),
+    }
+}
+
+fn failed_session(role: &str) -> AgentSession {
+    AgentSession {
+        role: role.to_string(),
+        session_id: format!("{role}-session"),
+        provider_session_id: None,
+        status: AgentSessionStatus::Failed,
+        output: vec![],
+        pending_follow_ups: vec![],
+        terminal_outcome: Some(AgentTerminalOutcome::Nok),
+    }
+}
+
+fn aborted_session(role: &str) -> AgentSession {
+    AgentSession {
+        role: role.to_string(),
+        session_id: format!("{role}-session"),
+        provider_session_id: None,
+        status: AgentSessionStatus::Aborted,
+        output: vec![],
+        pending_follow_ups: vec![],
+        terminal_outcome: Some(AgentTerminalOutcome::Aborted),
+    }
+}
+
+fn waiting_session(role: &str, question: &str) -> AgentSession {
+    AgentSession {
+        role: role.to_string(),
+        session_id: format!("{role}-session"),
+        provider_session_id: None,
+        status: AgentSessionStatus::WaitingForHuman,
+        output: vec![],
+        pending_follow_ups: vec![question.to_string()],
+        terminal_outcome: None,
+    }
+}
+
+// ── Feature builder ───────────────────────────────────────────────────────────
+
+fn feature_with_sessions(sessions: Vec<AgentSession>) -> FeatureState {
+    FeatureState {
+        feature_id: "feat-reporting".to_string(),
+        branch: "feat/reporting".to_string(),
+        worktree_path: "/tmp/reporting".to_string(),
+        pull_request: PullRequestRef {
+            number: 42,
+            url: "https://github.com/example/repo/pull/42".to_string(),
+        },
+        github_snapshot: None,
+        github_error: None,
+        workflow_state: WorkflowState::Implementation,
+        gate_groups: vec![GateGroup {
+            id: "ci".to_string(),
+            label: "CI".to_string(),
+            gates: vec![Gate {
+                id: "tests".to_string(),
+                label: "Tests green".to_string(),
+                task: "tests".to_string(),
+                status: GateStatus::Pending,
+            }],
+        }],
+        active_sessions: sessions,
+        feature_type: FeatureType::Feat,
+        roles: vec![],
+        scheduling: SchedulingMeta::default(),
+        artifact_refs: vec![],
+        transcript_refs: vec![],
+        clarification_history: vec![],
+    }
+}
+
+fn feature_empty() -> FeatureState {
+    let mut f = feature_with_sessions(vec![]);
+    f.gate_groups.clear();
+    f
+}
+
+/// Create a unique temp directory.
+fn temp_dir(label: &str) -> std::path::PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let dir = std::env::temp_dir().join(format!("calypso-reporting-{label}-{nanos}"));
+    std::fs::create_dir_all(&dir).expect("create temp dir");
+    dir
+}
+
+// ── Unit tests — text rendering ───────────────────────────────────────────────
+
+#[test]
+fn running_session_shows_running_status_in_render() {
+    let feature = feature_with_sessions(vec![running_session("engineer", &[])]);
+    let rendered = OperatorSurface::from_feature_state(&feature).render();
+    assert!(
+        rendered.contains("[running]"),
+        "running session should show [running] status"
+    );
+    assert!(
+        rendered.contains("engineer"),
+        "running session should show role name"
+    );
+}
+
+#[test]
+fn completed_session_shows_completed_status_in_render() {
+    let feature = feature_with_sessions(vec![completed_session("reviewer")]);
+    let rendered = OperatorSurface::from_feature_state(&feature).render();
+    assert!(
+        rendered.contains("[completed]"),
+        "completed session should show [completed] status"
+    );
+    assert!(rendered.contains("reviewer"));
+}
+
+#[test]
+fn failed_session_shows_failed_status_in_render() {
+    let feature = feature_with_sessions(vec![failed_session("validator")]);
+    let rendered = OperatorSurface::from_feature_state(&feature).render();
+    assert!(
+        rendered.contains("[failed]"),
+        "failed session should show [failed] status"
+    );
+    assert!(rendered.contains("validator"));
+}
+
+#[test]
+fn aborted_session_shows_aborted_status_in_render() {
+    let feature = feature_with_sessions(vec![aborted_session("orchestrator")]);
+    let rendered = OperatorSurface::from_feature_state(&feature).render();
+    assert!(
+        rendered.contains("[aborted]"),
+        "aborted session should show [aborted] status"
+    );
+    assert!(rendered.contains("orchestrator"));
+}
+
+#[test]
+fn session_output_lines_appear_in_render() {
+    let session = running_session(
+        "engineer",
+        &[
+            "Cloning repository",
+            "Running cargo build",
+            "Build succeeded",
+        ],
+    );
+    let feature = feature_with_sessions(vec![session]);
+    let rendered = OperatorSurface::from_feature_state(&feature).render();
+
+    assert!(
+        rendered.contains("Cloning repository"),
+        "first output line should appear in render"
+    );
+    assert!(
+        rendered.contains("Running cargo build"),
+        "second output line should appear in render"
+    );
+    assert!(
+        rendered.contains("Build succeeded"),
+        "third output line should appear in render"
+    );
+}
+
+#[test]
+fn pending_follow_ups_appear_in_render() {
+    let session = waiting_session("architect", "What branch should I target?");
+    let feature = feature_with_sessions(vec![session]);
+    let rendered = OperatorSurface::from_feature_state(&feature).render();
+
+    // The waiting session has a pending follow-up question in pending_follow_ups
+    assert!(
+        rendered.contains("architect"),
+        "waiting session role should appear"
+    );
+    assert!(
+        rendered.contains("[waiting-for-human]"),
+        "waiting session should show waiting status"
+    );
+}
+
+#[test]
+fn feature_with_no_sessions_shows_no_active_sessions() {
+    let feature = feature_empty();
+    let rendered = OperatorSurface::from_feature_state(&feature).render();
+    assert!(
+        rendered.contains("No active sessions"),
+        "feature with no sessions should render 'No active sessions'"
+    );
+}
+
+#[test]
+fn pending_clarification_appears_in_render() {
+    let mut feature = feature_with_sessions(vec![running_session("engineer", &[])]);
+    feature.clarification_history = vec![ClarificationEntry {
+        session_id: "engineer-session".to_string(),
+        question: "Which module should I modify?".to_string(),
+        answer: None,
+        timestamp: "2026-03-15T10:00:00Z".to_string(),
+    }];
+
+    let rendered = OperatorSurface::from_feature_state(&feature).render();
+
+    assert!(
+        rendered.contains("Which module should I modify?"),
+        "unanswered clarification question should appear in render"
+    );
+    assert!(
+        rendered.contains("Pending Clarifications"),
+        "pending clarifications section should appear"
+    );
+}
+
+// ── Integration tests — state file round-trip ─────────────────────────────────
+
+fn repo_state_with_sessions(sessions: Vec<AgentSession>) -> RepositoryState {
+    RepositoryState {
+        version: 1,
+        repo_id: "reporting-repo".to_string(),
+        schema_version: 2,
+        current_feature: feature_with_sessions(sessions),
+        identity: Default::default(),
+        providers: vec![],
+        releases: vec![],
+        deployments: vec![],
+    }
+}
+
+#[test]
+fn state_file_round_trip_three_sessions_all_roles_visible() {
+    let dir = temp_dir("round-trip-three");
+    let calypso_dir = dir.join(".calypso");
+    std::fs::create_dir_all(&calypso_dir).expect("create .calypso dir");
+    let state_path = calypso_dir.join("state.json");
+
+    // Build a RepositoryState with three sessions.
+    let sessions = vec![
+        running_session("engineer", &["Compiling crate"]),
+        completed_session("reviewer"),
+        failed_session("validator"),
+    ];
+    let original = repo_state_with_sessions(sessions);
+
+    // Serialize to disk.
+    original
+        .save_to_path(&state_path)
+        .expect("save state to disk");
+
+    // Load back.
+    let loaded = RepositoryState::load_from_path(&state_path).expect("load state from disk");
+
+    // Render via OperatorSurface.
+    let rendered = OperatorSurface::from_feature_state(&loaded.current_feature).render();
+
+    assert!(
+        rendered.contains("engineer"),
+        "loaded state should render engineer session"
+    );
+    assert!(
+        rendered.contains("reviewer"),
+        "loaded state should render reviewer session"
+    );
+    assert!(
+        rendered.contains("validator"),
+        "loaded state should render validator session"
+    );
+    assert!(
+        rendered.contains("[running]"),
+        "running session status should survive round-trip"
+    );
+    assert!(
+        rendered.contains("[completed]"),
+        "completed session status should survive round-trip"
+    );
+    assert!(
+        rendered.contains("[failed]"),
+        "failed session status should survive round-trip"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+// ── Edge cases ────────────────────────────────────────────────────────────────
+
+#[test]
+fn feature_with_zero_sessions_renders_no_active_sessions() {
+    let feature = feature_empty();
+    let rendered = OperatorSurface::from_feature_state(&feature).render();
+    assert!(
+        rendered.contains("No active sessions"),
+        "zero sessions should show 'No active sessions'"
+    );
+}
+
+#[test]
+fn session_with_ten_output_lines_all_appear_in_render() {
+    let lines: Vec<&str> = vec![
+        "Line 1: init",
+        "Line 2: fetch",
+        "Line 3: compile",
+        "Line 4: link",
+        "Line 5: test",
+        "Line 6: coverage",
+        "Line 7: lint",
+        "Line 8: format",
+        "Line 9: upload",
+        "Line 10: done",
+    ];
+    let session = running_session("engineer", &lines);
+    let feature = feature_with_sessions(vec![session]);
+    let rendered = OperatorSurface::from_feature_state(&feature).render();
+
+    for line in &lines {
+        assert!(
+            rendered.contains(line),
+            "output line '{line}' should appear in render"
+        );
+    }
+}
+
+#[test]
+fn session_with_pending_clarification_unanswered_question_appears() {
+    let mut feature = feature_with_sessions(vec![running_session("orchestrator", &[])]);
+    feature.clarification_history = vec![ClarificationEntry {
+        session_id: "orchestrator-session".to_string(),
+        question: "Should I use async or sync IO?".to_string(),
+        answer: None,
+        timestamp: "2026-03-15T10:00:00Z".to_string(),
+    }];
+
+    let rendered = OperatorSurface::from_feature_state(&feature).render();
+
+    assert!(
+        rendered.contains("Should I use async or sync IO?"),
+        "pending clarification question should appear in render"
+    );
+}
+
+#[test]
+fn answered_clarification_does_not_appear_in_pending_section() {
+    let mut feature = feature_with_sessions(vec![running_session("orchestrator", &[])]);
+    feature.clarification_history = vec![
+        ClarificationEntry {
+            session_id: "orchestrator-session".to_string(),
+            question: "Pending question".to_string(),
+            answer: None,
+            timestamp: "2026-03-15T10:00:00Z".to_string(),
+        },
+        ClarificationEntry {
+            session_id: "orchestrator-session".to_string(),
+            question: "Already answered question".to_string(),
+            answer: Some("Use async IO".to_string()),
+            timestamp: "2026-03-15T10:01:00Z".to_string(),
+        },
+    ];
+
+    let rendered = OperatorSurface::from_feature_state(&feature).render();
+
+    assert!(
+        rendered.contains("Pending question"),
+        "unanswered question should appear in render"
+    );
+    assert!(
+        !rendered.contains("Already answered question"),
+        "answered question should NOT appear in pending section"
+    );
+}
+
+#[test]
+fn state_file_round_trip_preserves_session_output_lines() {
+    let dir = temp_dir("round-trip-output");
+    let calypso_dir = dir.join(".calypso");
+    std::fs::create_dir_all(&calypso_dir).expect("create .calypso dir");
+    let state_path = calypso_dir.join("state.json");
+
+    let session = running_session("engineer", &["Build output line A", "Build output line B"]);
+    let original = repo_state_with_sessions(vec![session]);
+
+    original
+        .save_to_path(&state_path)
+        .expect("save state to disk");
+
+    let loaded = RepositoryState::load_from_path(&state_path).expect("load state from disk");
+    let rendered = OperatorSurface::from_feature_state(&loaded.current_feature).render();
+
+    assert!(
+        rendered.contains("Build output line A"),
+        "output line A should survive round-trip"
+    );
+    assert!(
+        rendered.contains("Build output line B"),
+        "output line B should survive round-trip"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/cli/tests/driver.rs
+++ b/cli/tests/driver.rs
@@ -98,6 +98,7 @@ fn driver_step_errors_when_state_file_missing() {
         state_path: std::path::PathBuf::from("/nonexistent/path/state.json"),
         template,
         config: ExecutionConfig::default(),
+        executor: None,
     };
 
     let result = driver.step();
@@ -115,6 +116,7 @@ fn run_auto_stops_on_first_error() {
         state_path: std::path::PathBuf::from("/nonexistent/path/state.json"),
         template,
         config: ExecutionConfig::default(),
+        executor: None,
     };
 
     let results = driver.run_auto();

--- a/cli/tests/fixtures/phony-template/.calypso/agents.yml
+++ b/cli/tests/fixtures/phony-template/.calypso/agents.yml
@@ -1,0 +1,13 @@
+# Phony agent task catalog for testing
+tasks:
+  - name: phony-alpha-task
+    kind: agent
+    role: phony-alpha-agent
+
+  - name: phony-beta-task
+    kind: agent
+    role: phony-beta-agent
+
+  - name: phony-gamma-task
+    kind: agent
+    role: phony-gamma-agent

--- a/cli/tests/fixtures/phony-template/.calypso/prompts.yml
+++ b/cli/tests/fixtures/phony-template/.calypso/prompts.yml
@@ -1,0 +1,8 @@
+# Phony prompts for testing
+prompts:
+  phony-alpha-task: |
+    You are the phony alpha agent. Complete the alpha step and emit [CALYPSO:OK].
+  phony-beta-task: |
+    You are the phony beta agent. Complete the beta step and emit [CALYPSO:OK].
+  phony-gamma-task: |
+    You are the phony gamma agent. Complete the gamma step and emit [CALYPSO:OK].

--- a/cli/tests/fixtures/phony-template/.calypso/state-machine.yml
+++ b/cli/tests/fixtures/phony-template/.calypso/state-machine.yml
@@ -1,0 +1,74 @@
+# Phony 3-step pipeline for testing
+# States: new -> prd-review -> architecture-plan (done/aborted as terminals)
+# Uses a subset of canonical WorkflowState slugs so the driver can parse them.
+initial_state: new
+
+states:
+  - new
+  - prd-review
+  - architecture-plan
+  - done
+  - blocked
+  - aborted
+
+transitions:
+  - from: new
+    to: prd-review
+  - from: prd-review
+    to: architecture-plan
+  - from: architecture-plan
+    to: done
+  - from: new
+    to: blocked
+  - from: prd-review
+    to: blocked
+  - from: architecture-plan
+    to: blocked
+  - from: blocked
+    to: new
+  - from: blocked
+    to: prd-review
+  - from: blocked
+    to: architecture-plan
+  - from: new
+    to: aborted
+  - from: prd-review
+    to: aborted
+  - from: architecture-plan
+    to: aborted
+  - from: blocked
+    to: aborted
+
+# Override policy_gates to empty so default bindings (which reference
+# default gate IDs) do not conflict with our phony gate_groups.
+policy_gates: []
+
+# Override artifact_policies to empty (no required artifacts in phony pipeline).
+artifact_policies:
+  required_per_state: {}
+
+gate_groups:
+  - id: phony-alpha
+    label: Alpha Gate Group
+    gates:
+      - id: phony-alpha-gate
+        label: Alpha task complete
+        task: phony-alpha-task
+        applies_to:
+          - new
+  - id: phony-beta
+    label: Beta Gate Group
+    gates:
+      - id: phony-beta-gate
+        label: Beta task complete
+        task: phony-beta-task
+        applies_to:
+          - prd-review
+  - id: phony-gamma
+    label: Gamma Gate Group
+    gates:
+      - id: phony-gamma-gate
+        label: Gamma task complete
+        task: phony-gamma-task
+        applies_to:
+          - architecture-plan

--- a/cli/tests/phony_template.rs
+++ b/cli/tests/phony_template.rs
@@ -1,0 +1,362 @@
+//! Tests for the phony-template fixture and the StateMachineDriver
+//! using an injectable PhonyExecutor.
+//!
+//! The phony template defines a minimal 3-step pipeline using canonical
+//! WorkflowState slugs: new -> prd-review -> architecture-plan.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use calypso_cli::driver::{DriverMode, DriverStepResult, SessionExecutor, StateMachineDriver};
+use calypso_cli::execution::{ExecutionConfig, ExecutionError, ExecutionOutcome};
+use calypso_cli::state::{
+    FeatureState, FeatureType, PullRequestRef, RepositoryState, SchedulingMeta, WorkflowState,
+};
+use calypso_cli::template::TemplateSet;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// Path to the phony template fixture directory (relative to the crate root).
+fn phony_template_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/phony-template")
+}
+
+/// Create a unique temp directory for a test.
+fn temp_dir(label: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let dir = std::env::temp_dir().join(format!("calypso-phony-{label}-{nanos}"));
+    std::fs::create_dir_all(&dir).expect("create temp dir");
+    dir
+}
+
+/// Build a minimal `RepositoryState` at the given `WorkflowState`.
+fn minimal_state(workflow_state: WorkflowState) -> RepositoryState {
+    RepositoryState {
+        version: 1,
+        repo_id: "phony-repo".to_string(),
+        schema_version: 2,
+        current_feature: FeatureState {
+            feature_id: "phony-feature".to_string(),
+            branch: "feat/phony".to_string(),
+            worktree_path: "/tmp".to_string(),
+            pull_request: PullRequestRef {
+                number: 1,
+                url: "https://github.com/example/repo/pull/1".to_string(),
+            },
+            github_snapshot: None,
+            github_error: None,
+            workflow_state,
+            gate_groups: vec![],
+            active_sessions: vec![],
+            feature_type: FeatureType::Feat,
+            roles: vec![],
+            scheduling: SchedulingMeta::default(),
+            artifact_refs: vec![],
+            transcript_refs: vec![],
+            clarification_history: vec![],
+        },
+        identity: Default::default(),
+        providers: vec![],
+        releases: vec![],
+        deployments: vec![],
+    }
+}
+
+/// Write a `RepositoryState` to a temp directory and return the state file path.
+fn write_state(dir: &Path, state: &RepositoryState) -> PathBuf {
+    let state_dir = dir.join(".calypso");
+    std::fs::create_dir_all(&state_dir).expect("create .calypso dir");
+    let path = state_dir.join("state.json");
+    state.save_to_path(&path).expect("save state");
+    path
+}
+
+// ── PhonyExecutor ─────────────────────────────────────────────────────────────
+
+/// A `SessionExecutor` that returns a pre-canned `ExecutionOutcome` without
+/// spawning any external process.  Used to drive the state machine in tests
+/// without a real Claude installation.
+struct PhonyExecutor {
+    outcome: ExecutionOutcome,
+}
+
+impl PhonyExecutor {
+    fn ok_advancing(next: WorkflowState) -> Arc<Self> {
+        Arc::new(Self {
+            outcome: ExecutionOutcome::Ok {
+                summary: "phony ok".to_string(),
+                artifact_refs: vec![],
+                advanced_to: Some(next),
+            },
+        })
+    }
+
+    fn ok_no_advance() -> Arc<Self> {
+        Arc::new(Self {
+            outcome: ExecutionOutcome::Ok {
+                summary: "phony ok no advance".to_string(),
+                artifact_refs: vec![],
+                advanced_to: None,
+            },
+        })
+    }
+
+    fn nok(reason: &str) -> Arc<Self> {
+        Arc::new(Self {
+            outcome: ExecutionOutcome::Nok {
+                summary: "phony nok".to_string(),
+                reason: reason.to_string(),
+            },
+        })
+    }
+}
+
+impl SessionExecutor for PhonyExecutor {
+    fn run(
+        &self,
+        _state_path: &std::path::Path,
+        _role: &str,
+        _config: &ExecutionConfig,
+    ) -> Result<ExecutionOutcome, ExecutionError> {
+        Ok(self.outcome.clone())
+    }
+}
+
+// ── Template unit tests ───────────────────────────────────────────────────────
+
+#[test]
+fn phony_template_loads_from_directory() {
+    let dir = phony_template_dir();
+    let result = TemplateSet::load_from_directory(&dir);
+    assert!(
+        result.is_ok(),
+        "phony template should load without error: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn phony_template_validates_with_zero_coherence_errors() {
+    let dir = phony_template_dir();
+    let template = TemplateSet::load_from_directory(&dir).expect("phony template loads");
+    let errors = template.validate_coherence();
+    assert!(
+        errors.is_empty(),
+        "phony template should have zero coherence errors; got: {errors:?}"
+    );
+}
+
+#[test]
+fn phony_template_initial_state_is_new() {
+    let dir = phony_template_dir();
+    let template = TemplateSet::load_from_directory(&dir).expect("phony template loads");
+    assert_eq!(
+        template.state_machine.initial_state, "new",
+        "phony template initial state should be 'new'"
+    );
+}
+
+#[test]
+fn phony_template_defines_task_for_each_gate() {
+    let dir = phony_template_dir();
+    let template = TemplateSet::load_from_directory(&dir).expect("phony template loads");
+
+    for group in &template.state_machine.gate_groups {
+        for gate in &group.gates {
+            let task = template.task_by_name(&gate.task);
+            assert!(
+                task.is_some(),
+                "gate '{}' references task '{}' which should exist in agents catalog",
+                gate.id,
+                gate.task
+            );
+        }
+    }
+}
+
+#[test]
+fn phony_template_has_three_gate_groups() {
+    let dir = phony_template_dir();
+    let template = TemplateSet::load_from_directory(&dir).expect("phony template loads");
+    assert_eq!(
+        template.state_machine.gate_groups.len(),
+        3,
+        "phony template should define exactly 3 gate groups (alpha, beta, gamma)"
+    );
+}
+
+// ── Driver integration tests ──────────────────────────────────────────────────
+
+/// Build a `StateMachineDriver` with the phony template and a given executor.
+fn phony_driver(state_path: PathBuf, executor: Arc<dyn SessionExecutor>) -> StateMachineDriver {
+    let template =
+        TemplateSet::load_from_directory(&phony_template_dir()).expect("phony template loads");
+    StateMachineDriver {
+        mode: DriverMode::Auto,
+        state_path,
+        template,
+        config: ExecutionConfig::default(),
+        executor: Some(executor),
+    }
+}
+
+#[test]
+fn driver_advances_from_new_to_prd_review_with_phony_ok() {
+    let dir = temp_dir("advance-new");
+    let state = minimal_state(WorkflowState::New);
+    let state_path = write_state(&dir, &state);
+
+    let executor = PhonyExecutor::ok_advancing(WorkflowState::PrdReview);
+    let driver = phony_driver(state_path, executor);
+
+    let result = driver.step();
+    assert_eq!(
+        result,
+        DriverStepResult::Advanced(WorkflowState::PrdReview),
+        "agent step on 'new' state should advance to 'prd-review'"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn driver_advances_from_prd_review_to_architecture_plan_with_phony_ok() {
+    let dir = temp_dir("advance-prd");
+    let state = minimal_state(WorkflowState::PrdReview);
+    let state_path = write_state(&dir, &state);
+
+    let executor = PhonyExecutor::ok_advancing(WorkflowState::ArchitecturePlan);
+    let driver = phony_driver(state_path, executor);
+
+    let result = driver.step();
+    assert_eq!(
+        result,
+        DriverStepResult::Advanced(WorkflowState::ArchitecturePlan),
+        "agent step on 'prd-review' should advance to 'architecture-plan'"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn driver_step_sequence_new_to_prd_review_to_architecture_plan() {
+    // Manually advance through the phony pipeline one step at a time,
+    // updating the state file between each call.
+    let dir = temp_dir("sequence");
+    let state_path = write_state(&dir, &minimal_state(WorkflowState::New));
+
+    // Step 1: new -> prd-review
+    let executor = PhonyExecutor::ok_advancing(WorkflowState::PrdReview);
+    let driver = phony_driver(state_path.clone(), executor);
+    let r1 = driver.step();
+    assert_eq!(r1, DriverStepResult::Advanced(WorkflowState::PrdReview));
+
+    // Advance state file manually (PhonyExecutor doesn't write to disk).
+    write_state(&dir, &minimal_state(WorkflowState::PrdReview));
+
+    // Step 2: prd-review -> architecture-plan
+    let executor = PhonyExecutor::ok_advancing(WorkflowState::ArchitecturePlan);
+    let driver = phony_driver(state_path.clone(), executor);
+    let r2 = driver.step();
+    assert_eq!(
+        r2,
+        DriverStepResult::Advanced(WorkflowState::ArchitecturePlan)
+    );
+
+    // Advance state file manually.
+    write_state(&dir, &minimal_state(WorkflowState::ArchitecturePlan));
+
+    // Step 3: architecture-plan has no further forward transition in the phony
+    // template; PhonyExecutor returns Ok with no advancement -> Unchanged.
+    let executor = PhonyExecutor::ok_no_advance();
+    let driver = phony_driver(state_path.clone(), executor);
+    let r3 = driver.step();
+    assert_eq!(
+        r3,
+        DriverStepResult::Unchanged,
+        "architecture-plan with no advance should be Unchanged"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn driver_stays_unchanged_when_executor_returns_ok_with_no_advance() {
+    let dir = temp_dir("unchanged");
+    let state = minimal_state(WorkflowState::New);
+    let state_path = write_state(&dir, &state);
+
+    let executor = PhonyExecutor::ok_no_advance();
+    let driver = phony_driver(state_path, executor);
+
+    let result = driver.step();
+    assert_eq!(
+        result,
+        DriverStepResult::Unchanged,
+        "ok with no advanced_to should produce Unchanged"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn driver_returns_failed_when_executor_returns_nok() {
+    let dir = temp_dir("failed");
+    let state = minimal_state(WorkflowState::New);
+    let state_path = write_state(&dir, &state);
+
+    let executor = PhonyExecutor::nok("simulated gate failure");
+    let driver = phony_driver(state_path, executor);
+
+    let result = driver.step();
+    assert!(
+        matches!(result, DriverStepResult::Failed { .. }),
+        "NOK executor outcome should produce Failed driver result, got: {result:?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn run_auto_stops_on_failed_result() {
+    let dir = temp_dir("auto-stop");
+    let state = minimal_state(WorkflowState::New);
+    let state_path = write_state(&dir, &state);
+
+    let executor = PhonyExecutor::nok("gate blocked");
+    let driver = phony_driver(state_path, executor);
+
+    let results = driver.run_auto();
+    assert_eq!(
+        results.len(),
+        1,
+        "run_auto should stop after first Failed step"
+    );
+    assert!(matches!(results[0], DriverStepResult::Failed { .. }));
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn driver_errors_when_state_file_missing_with_phony_executor() {
+    let executor = PhonyExecutor::ok_no_advance();
+    let template =
+        TemplateSet::load_from_directory(&phony_template_dir()).expect("phony template loads");
+    let driver = StateMachineDriver {
+        mode: DriverMode::Auto,
+        state_path: PathBuf::from("/nonexistent/phony-state.json"),
+        template,
+        config: ExecutionConfig::default(),
+        executor: Some(executor),
+    };
+
+    let result = driver.step();
+    assert!(
+        matches!(result, DriverStepResult::Error(_)),
+        "missing state file should produce Error, got: {result:?}"
+    );
+}


### PR DESCRIPTION
## Summary

- Adds a `SessionExecutor` trait to `cli/src/driver.rs` with a `RealExecutor` (wraps `run_supervised_session`) and a pluggable `executor: Option<Arc<dyn SessionExecutor>>` field on `StateMachineDriver`
- Adds a phony 3-step template fixture (`cli/tests/fixtures/phony-template/.calypso/`) using canonical WorkflowState slugs (`new → prd-review → architecture-plan`) with minimal agent tasks and prompts
- Adds `cli/tests/phony_template.rs` (12 tests): template load/coherence/structure unit tests + driver integration tests using `PhonyExecutor`
- Adds `cli/tests/agent_reporting.rs` (14 tests): session builder helpers, `OperatorSurface` rendering assertions for all status variants, state file round-trips, and edge cases

Closes #111, closes #112.

## Key decisions

- `PhonyExecutor` returns pre-canned `ExecutionOutcome` values without touching the state file; driver integration tests that need to sequence through states manually advance the state file between calls to `driver.step()` — this keeps the executor simple and side-effect-free
- The phony template YAML uses the existing `WorkflowState` enum slugs rather than inventing custom state names, since the driver decodes state names via the canonical enum
- `policy_gates: []` and `artifact_policies: required_per_state: {}` are explicitly declared in the phony fixture's state-machine override to prevent default policy-gate bindings (which reference default gate IDs) from failing validation

## Test plan

- [x] `cargo test --test phony_template` — 12 tests green
- [x] `cargo test --test agent_reporting` — 14 tests green
- [x] `cargo test` — all 43 integration tests + doc tests green
- [x] `cargo clippy --tests -- -D warnings` — clean
- [x] `cargo fmt --check` — clean