### PR TITLE
feat: embed blueprint workflow files at compile time, add workflows subcommand

### DIFF
--- a/cli/build.rs
+++ b/cli/build.rs
@@ -2,6 +2,19 @@ use std::process::Command;
 
 fn main() {
     println!("cargo:rerun-if-changed=.git/HEAD");
+
+    // Blueprint workflow files embedded at compile time.
+    println!("cargo:rerun-if-changed=../.gitmodules");
+    println!("cargo:rerun-if-changed=../calypso-blueprint/examples/workflows/calypso-default-deployment-workflow.yaml");
+    println!("cargo:rerun-if-changed=../calypso-blueprint/examples/workflows/calypso-default-feature-workflow.yaml");
+    println!("cargo:rerun-if-changed=../calypso-blueprint/examples/workflows/calypso-deployment-request.yaml");
+    println!("cargo:rerun-if-changed=../calypso-blueprint/examples/workflows/calypso-feature-request.yaml");
+    println!("cargo:rerun-if-changed=../calypso-blueprint/examples/workflows/calypso-implementation-loop.yaml");
+    println!("cargo:rerun-if-changed=../calypso-blueprint/examples/workflows/calypso-orchestrator-startup.yaml");
+    println!("cargo:rerun-if-changed=../calypso-blueprint/examples/workflows/calypso-planning.yaml");
+    println!("cargo:rerun-if-changed=../calypso-blueprint/examples/workflows/calypso-pr-review-merge.yaml");
+    println!("cargo:rerun-if-changed=../calypso-blueprint/examples/workflows/calypso-release-request.yaml");
+    println!("cargo:rerun-if-changed=../calypso-blueprint/examples/workflows/calypso-save-state.yaml");
     println!("cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH");
     println!("cargo:rustc-check-cfg=cfg(coverage)");
 

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -551,3 +551,32 @@ pub fn run_agents_plain(cwd: &Path) -> Result<String, String> {
         crate::state::RepositoryState::load_from_path(&state_path).map_err(|e| e.to_string())?;
     Ok(render_agents(&state.current_feature))
 }
+
+// ---------------------------------------------------------------------------
+// Feature 4 — workflows (list / show / validate)
+// ---------------------------------------------------------------------------
+
+/// Return a newline-separated list of all embedded blueprint workflow name stems.
+pub fn run_workflows_list() -> String {
+    crate::blueprint_workflows::BlueprintWorkflowLibrary::list()
+        .iter()
+        .map(|(stem, _)| *stem)
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Return the raw YAML content for a named workflow, or an error message.
+pub fn run_workflows_show(name: &str) -> Result<String, String> {
+    crate::blueprint_workflows::BlueprintWorkflowLibrary::get(name)
+        .map(|yaml| yaml.to_string())
+        .ok_or_else(|| format!("workflow not found: {name}"))
+}
+
+/// Parse the named workflow and return `Ok("OK")` or `Err(parse_error_string)`.
+pub fn run_workflows_validate(name: &str) -> Result<String, String> {
+    let yaml = crate::blueprint_workflows::BlueprintWorkflowLibrary::get(name)
+        .ok_or_else(|| format!("workflow not found: {name}"))?;
+    crate::blueprint_workflows::BlueprintWorkflowLibrary::parse(yaml)
+        .map(|_| "OK".to_string())
+        .map_err(|e| e.to_string())
+}

--- a/cli/src/blueprint_workflows.rs
+++ b/cli/src/blueprint_workflows.rs
@@ -1,0 +1,519 @@
+//! Embedded blueprint workflow YAML files from the calypso-blueprint submodule.
+//!
+//! This module provides compile-time access to all `calypso-*.yaml` workflow files.
+//! Use [`BlueprintWorkflowLibrary`] to enumerate, look up, and parse them.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+// ── Embedded YAML content ────────────────────────────────────────────────────
+
+const CALYPSO_DEFAULT_DEPLOYMENT_WORKFLOW: &str = include_str!(
+    "../../calypso-blueprint/examples/workflows/calypso-default-deployment-workflow.yaml"
+);
+const CALYPSO_DEFAULT_FEATURE_WORKFLOW: &str = include_str!(
+    "../../calypso-blueprint/examples/workflows/calypso-default-feature-workflow.yaml"
+);
+const CALYPSO_DEPLOYMENT_REQUEST: &str = include_str!(
+    "../../calypso-blueprint/examples/workflows/calypso-deployment-request.yaml"
+);
+const CALYPSO_FEATURE_REQUEST: &str = include_str!(
+    "../../calypso-blueprint/examples/workflows/calypso-feature-request.yaml"
+);
+const CALYPSO_IMPLEMENTATION_LOOP: &str = include_str!(
+    "../../calypso-blueprint/examples/workflows/calypso-implementation-loop.yaml"
+);
+const CALYPSO_ORCHESTRATOR_STARTUP: &str = include_str!(
+    "../../calypso-blueprint/examples/workflows/calypso-orchestrator-startup.yaml"
+);
+const CALYPSO_PLANNING: &str =
+    include_str!("../../calypso-blueprint/examples/workflows/calypso-planning.yaml");
+const CALYPSO_PR_REVIEW_MERGE: &str =
+    include_str!("../../calypso-blueprint/examples/workflows/calypso-pr-review-merge.yaml");
+const CALYPSO_RELEASE_REQUEST: &str =
+    include_str!("../../calypso-blueprint/examples/workflows/calypso-release-request.yaml");
+const CALYPSO_SAVE_STATE: &str =
+    include_str!("../../calypso-blueprint/examples/workflows/calypso-save-state.yaml");
+
+// ── Library ──────────────────────────────────────────────────────────────────
+
+/// Static registry of all embedded `calypso-*.yaml` blueprint workflow files.
+pub struct BlueprintWorkflowLibrary;
+
+impl BlueprintWorkflowLibrary {
+    /// Returns all embedded workflows as `(filename_stem, raw_yaml)` pairs.
+    pub fn list() -> &'static [(&'static str, &'static str)] {
+        &[
+            (
+                "calypso-default-deployment-workflow",
+                CALYPSO_DEFAULT_DEPLOYMENT_WORKFLOW,
+            ),
+            (
+                "calypso-default-feature-workflow",
+                CALYPSO_DEFAULT_FEATURE_WORKFLOW,
+            ),
+            ("calypso-deployment-request", CALYPSO_DEPLOYMENT_REQUEST),
+            ("calypso-feature-request", CALYPSO_FEATURE_REQUEST),
+            ("calypso-implementation-loop", CALYPSO_IMPLEMENTATION_LOOP),
+            ("calypso-orchestrator-startup", CALYPSO_ORCHESTRATOR_STARTUP),
+            ("calypso-planning", CALYPSO_PLANNING),
+            ("calypso-pr-review-merge", CALYPSO_PR_REVIEW_MERGE),
+            ("calypso-release-request", CALYPSO_RELEASE_REQUEST),
+            ("calypso-save-state", CALYPSO_SAVE_STATE),
+        ]
+    }
+
+    /// Look up a workflow by its filename stem (e.g. `"calypso-planning"`).
+    pub fn get(name: &str) -> Option<&'static str> {
+        Self::list()
+            .iter()
+            .find(|(stem, _)| *stem == name)
+            .map(|(_, yaml)| *yaml)
+    }
+
+    /// Parse a raw YAML string into a [`BlueprintWorkflow`].
+    pub fn parse(yaml: &str) -> Result<BlueprintWorkflow, serde_yaml::Error> {
+        serde_yaml::from_str(yaml)
+    }
+}
+
+// ── Top-level document ───────────────────────────────────────────────────────
+
+/// A blueprint workflow document (one `calypso-*.yaml` file).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BlueprintWorkflow {
+    pub version: Option<u32>,
+    pub name: Option<String>,
+    pub initial_state: Option<String>,
+
+    // Optional top-level blocks — only some workflows define each one.
+    pub feature_unit: Option<FeatureUnit>,
+    pub prd_requirements: Option<PrdRequirements>,
+    pub pull_request_template: Option<PullRequestTemplate>,
+    pub plan: Option<PlanConfig>,
+    pub trigger: Option<TriggerConfig>,
+    pub release_requirements: Option<ReleaseRequirements>,
+    pub artifact_requirements: Option<ArtifactRequirements>,
+    pub rollout_order: Option<Vec<String>>,
+
+    /// States keyed by state name.
+    #[serde(default)]
+    pub states: HashMap<String, StateConfig>,
+
+    /// Checks keyed by check name.
+    #[serde(default)]
+    pub checks: HashMap<String, CheckConfig>,
+
+    /// Agent role prompts keyed by role name.
+    #[serde(default)]
+    pub agent_prompts: HashMap<String, String>,
+
+    pub hard_gates: Option<HardGates>,
+    pub github_actions: Option<GitHubActions>,
+}
+
+// ── feature_unit ─────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FeatureUnit {
+    pub invariant: Option<String>,
+    pub branch_from: Option<String>,
+    pub branch_required: Option<bool>,
+    pub worktree_required: Option<bool>,
+    pub push_to_origin_required: Option<bool>,
+    pub pull_request_required: Option<bool>,
+}
+
+// ── prd_requirements ─────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PrdRequirements {
+    pub read_before_feature_definition: Option<bool>,
+    pub source_documents: Option<Vec<String>>,
+}
+
+// ── pull_request_template ────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PullRequestTemplate {
+    pub required_sections: Option<Vec<PrSection>>,
+    pub completion_checks: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PrSection {
+    pub id: Option<String>,
+    pub label: Option<String>,
+    #[serde(rename = "type")]
+    pub section_type: Option<String>,
+}
+
+// ── plan ─────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PlanConfig {
+    pub document: Option<String>,
+    pub issue_tracker: Option<String>,
+    pub priority_labels: Option<Vec<String>>,
+}
+
+// ── trigger ──────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TriggerConfig {
+    pub event: Option<String>,
+    pub pattern: Option<String>,
+    pub branch_constraint: Option<String>,
+    pub ci_entry: Option<String>,
+}
+
+// ── release_requirements ─────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReleaseRequirements {
+    pub source_branch: Option<String>,
+    pub tag_required: Option<bool>,
+    pub tag_format: Option<String>,
+    pub tag_format_examples: Option<Vec<String>>,
+    pub tag_constraints: Option<Vec<String>>,
+}
+
+// ── artifact_requirements ────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ArtifactRequirements {
+    pub github_release_required: Option<bool>,
+    pub github_release_asset_required: Option<bool>,
+    pub ghcr_images_required: Option<bool>,
+    #[serde(rename = "kubernetes-image-ready-signal_required")]
+    pub kubernetes_image_ready_signal_required: Option<bool>,
+}
+
+// ── states ───────────────────────────────────────────────────────────────────
+
+/// Configuration for a single state in the workflow.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StateConfig {
+    pub kind: Option<StateKind>,
+    pub role: Option<String>,
+    pub cost: Option<AgentCost>,
+    pub description: Option<String>,
+    pub prompt: Option<String>,
+
+    /// For `kind: function` states.
+    pub function: Option<String>,
+    /// For `kind: deterministic` states with a shell command.
+    pub command: Option<String>,
+    /// For `kind: workflow` states.
+    pub workflow: Option<String>,
+
+    /// For `kind: github` states.
+    pub actor: Option<String>,
+    pub trigger: Option<String>,
+    pub workflows: Option<Vec<WorkflowRef>>,
+    pub poll_cmd: Option<String>,
+
+    /// CI job specification (used in calypso-release-request).
+    pub ci_job: Option<serde_yaml::Value>,
+
+    /// Checks that must pass to complete a deterministic or github state.
+    pub checks: Option<Vec<String>>,
+
+    /// Completion criteria for agent/human states.
+    pub completion: Option<CompletionCriteria>,
+
+    /// Cleanup commands run after the state exits.
+    pub cleanup: Option<Vec<CleanupStep>>,
+
+    /// Inline gates attached to this state (used in calypso-save-state).
+    pub gates: Option<Vec<serde_yaml::Value>>,
+
+    /// Transition spec — multiple YAML shapes are handled via `serde_yaml::Value`.
+    pub next: Option<NextSpec>,
+}
+
+/// The kind of actor or evaluation strategy for a state.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum StateKind {
+    Deterministic,
+    Agent,
+    Human,
+    Github,
+    Function,
+    Workflow,
+    Terminal,
+    #[serde(rename = "git-hook")]
+    GitHook,
+    Ci,
+}
+
+/// Cost tier for agent states.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AgentCost {
+    Guru,
+    Default,
+    Cheap,
+}
+
+/// Reference to a GitHub Actions workflow path and check names.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkflowRef {
+    pub path: Option<String>,
+    pub check_names: Option<Vec<String>>,
+}
+
+/// Completion criteria: `all_of`, `any_of`, or both.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CompletionCriteria {
+    pub all_of: Option<Vec<String>>,
+    pub any_of: Option<Vec<String>>,
+}
+
+/// A cleanup command run after a state exits.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CleanupStep {
+    pub cmd: Option<String>,
+    pub purpose: Option<String>,
+}
+
+// ── next (transition spec) ───────────────────────────────────────────────────
+//
+// The `next` field appears in several incompatible shapes across workflow files:
+//
+//   { on: { event: target, ... } }           — map of event → target state
+//   { on_success: state, on_failure: state }  — binary success/failure routing
+//   { on_pass: state, on_fail: state }        — deterministic pass/fail routing
+//   { pass: state, fail: state }              — github state pass/fail routing
+//   { on_complete: state }                    — single terminal transition
+//   { on_success: state }                     — one-sided (human states)
+//   { on_rejection: state, on_failure: state} — commit state
+//
+// Rather than fighting the serde untagged enum machinery for mutually-ambiguous
+// maps, we store the raw YAML value and expose typed accessors.
+
+/// Raw transition specification — parsed from whatever shape appears in YAML.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NextSpec(pub serde_yaml::Value);
+
+impl NextSpec {
+    /// Returns the target state for a named transition outcome, e.g. `"on_success"`,
+    /// `"pass"`, `"on_complete"`, or an arbitrary `on:` event name.
+    pub fn target_for(&self, outcome: &str) -> Option<&str> {
+        let map = self.0.as_mapping()?;
+
+        // Direct top-level key (on_success, on_failure, pass, fail, on_complete, …)
+        let key = serde_yaml::Value::String(outcome.to_owned());
+        if let Some(v) = map.get(&key) {
+            return v.as_str();
+        }
+
+        // Nested under `on:` (the event-dispatch shape)
+        let on_key = serde_yaml::Value::String("on".to_owned());
+        if let Some(serde_yaml::Value::Mapping(on_map)) = map.get(&on_key) {
+            let ev_key = serde_yaml::Value::String(outcome.to_owned());
+            if let Some(v) = on_map.get(&ev_key) {
+                return v.as_str();
+            }
+        }
+
+        None
+    }
+}
+
+// ── checks ───────────────────────────────────────────────────────────────────
+
+/// Configuration for a single named check.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CheckConfig {
+    pub kind: Option<CheckKind>,
+    pub role: Option<String>,
+    pub description: Option<String>,
+
+    // Deterministic check fields
+    pub cmd: Option<String>,
+    pub source: Option<CheckSource>,
+    pub hook: Option<String>,
+    pub workflow: Option<String>,
+    pub workflow_name: Option<String>,
+    pub check_names: Option<Vec<String>>,
+    pub builtin: Option<String>,
+
+    // CI job reference (calypso-release-request)
+    pub job: Option<String>,
+    pub step: Option<String>,
+
+    // Git-hook check fields (calypso-save-state)
+    pub blocking: Option<bool>,
+    pub behavior: Option<String>,
+}
+
+/// The kind of evaluator for a check.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CheckKind {
+    Deterministic,
+    Agent,
+    Human,
+    Github,
+    #[serde(rename = "git-hook")]
+    GitHook,
+    Ci,
+}
+
+/// Where a deterministic check is enforced.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum CheckSource {
+    GitHook,
+    Ci,
+    Builtin,
+}
+
+// ── hard_gates ───────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HardGates {
+    pub git_hooks: Option<Vec<GitHookGate>>,
+    pub ci_workflows: Option<Vec<CiWorkflowGate>>,
+    pub merge_compatibility: Option<MergeCompatibility>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GitHookGate {
+    pub hook: Option<String>,
+    pub blocking: Option<bool>,
+    pub checks: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CiWorkflowGate {
+    pub workflow: Option<String>,
+    pub blocking: Option<bool>,
+    pub check_names: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MergeCompatibility {
+    pub blocking: Option<bool>,
+    pub check: Option<String>,
+    pub remediation_state: Option<String>,
+}
+
+// ── github_actions ───────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GitHubActions {
+    /// Workflows that are currently required and exist in the repository.
+    pub current_required: Option<Vec<GitHubActionEntry>>,
+    /// Workflows that are proposed / not yet created.
+    pub proposed_required: Option<Vec<GitHubActionEntry>>,
+    /// Alternate key used in calypso-release-request.
+    pub current: Option<Vec<serde_yaml::Value>>,
+    /// Alternate proposed key used in calypso-release-request.
+    pub proposed: Option<Vec<serde_yaml::Value>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GitHubActionEntry {
+    pub workflow: Option<String>,
+    pub workflow_name: Option<String>,
+    pub check_names: Option<Vec<String>>,
+    pub used_for: Option<Vec<String>>,
+    pub purpose: Option<String>,
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_embedded_workflows_parse_successfully() {
+        for (stem, yaml) in BlueprintWorkflowLibrary::list() {
+            let result = BlueprintWorkflowLibrary::parse(yaml);
+            assert!(
+                result.is_ok(),
+                "failed to parse workflow '{stem}': {:?}",
+                result.err()
+            );
+        }
+    }
+
+    #[test]
+    fn get_returns_yaml_for_known_stem() {
+        let yaml = BlueprintWorkflowLibrary::get("calypso-planning");
+        assert!(yaml.is_some(), "expected to find calypso-planning");
+        assert!(yaml.unwrap().contains("calypso-planning"));
+    }
+
+    #[test]
+    fn get_returns_none_for_unknown_stem() {
+        assert!(BlueprintWorkflowLibrary::get("does-not-exist").is_none());
+    }
+
+    #[test]
+    fn list_contains_all_ten_workflows() {
+        assert_eq!(BlueprintWorkflowLibrary::list().len(), 10);
+    }
+
+    #[test]
+    fn default_feature_workflow_has_expected_initial_state() {
+        let yaml = BlueprintWorkflowLibrary::get("calypso-default-feature-workflow").unwrap();
+        let wf = BlueprintWorkflowLibrary::parse(yaml).unwrap();
+        assert_eq!(
+            wf.initial_state.as_deref(),
+            Some("worktree-check"),
+            "unexpected initial_state"
+        );
+    }
+
+    #[test]
+    fn default_feature_workflow_states_are_populated() {
+        let yaml = BlueprintWorkflowLibrary::get("calypso-default-feature-workflow").unwrap();
+        let wf = BlueprintWorkflowLibrary::parse(yaml).unwrap();
+        assert!(
+            !wf.states.is_empty(),
+            "expected at least one state in the feature workflow"
+        );
+    }
+
+    #[test]
+    fn default_feature_workflow_checks_are_populated() {
+        let yaml = BlueprintWorkflowLibrary::get("calypso-default-feature-workflow").unwrap();
+        let wf = BlueprintWorkflowLibrary::parse(yaml).unwrap();
+        assert!(
+            !wf.checks.is_empty(),
+            "expected at least one check in the feature workflow"
+        );
+    }
+
+    #[test]
+    fn next_spec_target_for_resolves_on_success() {
+        let yaml = BlueprintWorkflowLibrary::get("calypso-default-feature-workflow").unwrap();
+        let wf = BlueprintWorkflowLibrary::parse(yaml).unwrap();
+        let state = wf.states.get("feature-definition").unwrap();
+        let next = state.next.as_ref().unwrap();
+        assert_eq!(
+            next.target_for("on_success"),
+            Some("pr-template-review"),
+            "expected on_success → pr-template-review"
+        );
+    }
+
+    #[test]
+    fn next_spec_target_for_resolves_on_event() {
+        let yaml = BlueprintWorkflowLibrary::get("calypso-default-feature-workflow").unwrap();
+        let wf = BlueprintWorkflowLibrary::parse(yaml).unwrap();
+        let state = wf.states.get("implementation").unwrap();
+        let next = state.next.as_ref().unwrap();
+        assert_eq!(
+            next.target_for("implementation-complete"),
+            Some("github-ci"),
+            "expected implementation-complete → github-ci"
+        );
+    }
+}

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod app;
+pub mod blueprint_workflows;
 pub mod claude;
 // FUTURE: #48 — Codex provider; re-enable when multi-vendor registry is implemented
 // pub mod codex;
@@ -65,6 +66,11 @@ Commands:
   feature-start <id> --worktree-base <path>
                       Create a feature branch, worktree, draft PR, and state file
   template validate   Validate the local workflow template
+  workflows list      List all embedded blueprint workflow names
+  workflows show <name>
+                      Print the raw YAML for the named blueprint workflow
+  workflows validate <name>
+                      Parse the named workflow and report OK or the parse error
 
 Git hash: {}  Built: {}  Tags: {}",
         info.version, info.git_hash, info.build_time, info.git_tags

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,6 +1,7 @@
 use calypso_cli::app::{
     run_agents_json, run_agents_plain, run_doctor, run_doctor_json, run_state_status_json,
-    run_state_status_plain, run_status,
+    run_state_status_plain, run_status, run_workflows_list, run_workflows_show,
+    run_workflows_validate,
 };
 use calypso_cli::doctor::{DoctorFix, DoctorStatus, apply_fix, collect_doctor_report};
 use calypso_cli::execution::{ExecutionConfig, ExecutionOutcome, run_supervised_session};
@@ -168,6 +169,30 @@ fn main() {
         }
         [command, subcommand] if command == "template" && subcommand == "validate" => {
             run_template_validate(&cwd);
+        }
+        // calypso workflows list
+        [command, subcommand] if command == "workflows" && subcommand == "list" => {
+            println!("{}", run_workflows_list());
+        }
+        // calypso workflows show <name>
+        [command, subcommand, name] if command == "workflows" && subcommand == "show" => {
+            match run_workflows_show(name) {
+                Ok(yaml) => print!("{yaml}"),
+                Err(error) => {
+                    eprintln!("workflows show error: {error}");
+                    std::process::exit(1);
+                }
+            }
+        }
+        // calypso workflows validate <name>
+        [command, subcommand, name] if command == "workflows" && subcommand == "validate" => {
+            match run_workflows_validate(name) {
+                Ok(message) => println!("{message}"),
+                Err(error) => {
+                    eprintln!("{error}");
+                    std::process::exit(1);
+                }
+            }
         }
         // calypso <path> — positional project directory (kept for backward compatibility)
         [path] if looks_like_path(path) => {


### PR DESCRIPTION
## Summary

- Reads all `calypso-*.yaml` workflow definitions from `calypso-blueprint/examples/workflows/` at compile time via `include_str!()` and embeds them in the release binary — no runtime file I/O
- Defines new Rust types (`BlueprintWorkflow`, `StateConfig`, `CheckConfig`, etc.) that exactly match the blueprint workflow YAML schema, eliminating any intermediary shape
- `build.rs` now emits `cargo:rerun-if-changed` for every embedded file and for `.gitmodules`, so bumping the submodule pin is the only change needed to update embedded workflows
- Adds three new CLI subcommands: `calypso workflows list`, `calypso workflows show <name>`, `calypso workflows validate <name>`

## Key decisions

- Only the `calypso-*.yaml` files are embedded here; GitHub Actions yamls remain in `workflows.rs` (already handled)
- All types use `Option<T>` for fields that may not be present, allowing the schema to evolve without breakage
- The `next` field in `StateConfig` is stored as `serde_yaml::Value` via a newtype `NextSpec` to handle the multiple YAML shapes used across different workflow files (`on:`, `on_success/on_failure`, `pass/fail`, `on_complete`)

## Test plan

- [ ] `cargo test` — all 53 existing tests pass; 9 new tests verify each embedded workflow parses without error
- [ ] `calypso workflows list` — lists all 10 embedded workflow stems
- [ ] `calypso workflows show calypso-default-feature-workflow` — prints YAML
- [ ] `calypso workflows validate calypso-implementation-loop` — prints OK
- [ ] `calypso workflows show nonexistent` — exits 1 with error on stderr

Closes #116