### PR TITLE
feat: cargo run defaults to calypso-cli binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # LLVM coverage profiling data
 *.profraw
 .claude/
+target/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "calypso-cli"
@@ -96,9 +96,9 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "lock_api"
@@ -117,9 +117,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mio"
@@ -167,9 +167,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -180,7 +180,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -191,9 +191,9 @@ checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "ryu"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "scopeguard"
@@ -296,9 +296,9 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -307,9 +307,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -428,6 +428,6 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "zmij"
-version = "1.0.19"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,4 @@
+[workspace]
+members = ["cli"]
+default-members = ["cli"]
+resolver = "3"

--- a/cli/README.md
+++ b/cli/README.md
@@ -9,7 +9,10 @@ The command-line interface for Calypso, built in Rust.
 
 ## Running
 
+`cargo run` works from both the repository root and the `cli/` directory — the workspace `Cargo.toml` at the repo root sets `default-members = ["cli"]` and the crate's `default-run = "calypso-cli"`, so no `--bin` flag is needed.
+
 ```sh
+# From the repository root or cli/ directory:
 cargo run                        # launch TUI from current directory
 cargo run -- ./my-project        # launch TUI for a specific project directory
 cargo run -- /abs/path/to/proj   # absolute path also works
@@ -18,9 +21,11 @@ cargo run -- ~/projects/calypso  # tilde paths also work
 cargo run -- doctor              # run prerequisite checks
 cargo run -- status              # print feature gate summary
 cargo run -- watch               # live-reload TUI from current directory
-```
 
-`cargo run` defaults to the `calypso-cli` binary (via `default-run` in `Cargo.toml`), so no `--bin` flag is needed.
+# Release builds work the same way:
+cargo run --release              # launch TUI (optimized build)
+cargo run --release -- doctor    # run doctor (optimized build)
+```
 
 ## Path argument
 
@@ -55,7 +60,7 @@ calypso /abs/path        # uses /abs/path/.calypso/state.json
 
 ```bash
 git clone https://github.com/dot-matrix-labs/calypso.git
-cd calypso/cli
+cd calypso
 cargo build --release
 ```
 
@@ -63,7 +68,7 @@ The binary will be at `target/release/calypso-cli`.
 
 To install globally:
 ```bash
-cargo install --path .
+cargo install --path cli
 ```
 
 ## Development

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -44,12 +44,15 @@ pub fn render_help(info: BuildInfo<'_>) -> String {
 calypso-cli {}
 
 Usage:
-  calypso [OPTIONS] [COMMAND]
+  calypso [OPTIONS] [path] [COMMAND]
 
 Options:
   -p, --path <dir>    Project directory (default: current working directory)
   -h, --help          Show this help output
   -v, --version       Show build version information
+
+Positional:
+  [path]              Project directory (alternative to --path); starts TUI
 
 Commands:
   (none)              Drive the state machine for the project directory


### PR DESCRIPTION
## Summary

- Adds a workspace-level `Cargo.toml` at the repo root with `default-members = ["cli"]` and `resolver = "3"`, so `cargo run` (and `cargo run --release`) from the repository root builds and runs `calypso-cli` without needing `--bin calypso-cli`.
- Moves `Cargo.lock` from `cli/` to the workspace root (standard Cargo workspace layout).
- Adds `target/` to the root `.gitignore` (workspace builds output to `./target/` instead of `cli/target/`).
- Documents the positional `[path]` argument in the help text (`calypso [OPTIONS] [path] [COMMAND]`).
- Updates `cli/README.md` to reflect building and running from the repo root.

## Key decisions

- **Workspace with single member**: even though there is only one crate today, a workspace `Cargo.toml` is the standard way to let `cargo run` work from the repo root. Adding future crates to the workspace will be trivial.
- **`resolver = "3"`**: matches the crate's `edition = "2024"` requirement.
- **`cli/Cargo.lock` removed**: Cargo workspaces use a single `Cargo.lock` at the workspace root; the per-crate lock file is no longer used.

## Test plan

- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes (all 53 unit tests, integration tests, doc-tests)
- [x] `cargo run -- --help` from repo root shows updated help with `[path]` positional
- [x] `cargo check` from repo root compiles successfully

Closes #91