### PR TITLE
ci: restore 99% coverage gate for Phase 3

### DIFF
--- a/.github/workflows/rust-coverage.yml
+++ b/.github/workflows/rust-coverage.yml
@@ -30,7 +30,7 @@ jobs:
           workspaces: |
             cli -> target
 
-      - name: Run coverage with 90% line threshold
+      - name: Run coverage with 99% line threshold
         working-directory: cli
         run: cargo coverage
 
@@ -46,5 +46,5 @@ jobs:
         run: |
           echo "## CLI Coverage" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Enforced line coverage target: 90% (returns to 99% at Phase 3)" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Enforced line coverage target: 99%" >> "$GITHUB_STEP_SUMMARY"
           echo "- LCOV artifact: cli-coverage-lcov" >> "$GITHUB_STEP_SUMMARY"

--- a/cli/src/bin/coverage_driver.rs
+++ b/cli/src/bin/coverage_driver.rs
@@ -33,14 +33,14 @@ fn run() -> Result<(), String> {
         Ok(())
     } else {
         Err(format!(
-            "Line coverage below target: {covered}/{total} ({:.2}% < 90.00%)",
+            "Line coverage below target: {covered}/{total} ({:.2}% < 99.00%)",
             coverage_percent(covered, total)
         ))
     }
 }
 
 fn meets_line_threshold(covered: u64, total: u64) -> bool {
-    coverage_percent(covered, total) >= 90.0
+    coverage_percent(covered, total) >= 99.0
 }
 
 fn coverage_percent(covered: u64, total: u64) -> f64 {
@@ -111,8 +111,8 @@ end_of_record
 
     #[test]
     fn line_threshold_accepts_99_percent_or_more() {
-        assert!(meets_line_threshold(90, 100));
+        assert!(meets_line_threshold(99, 100));
         assert!(meets_line_threshold(100, 100));
-        assert!(!meets_line_threshold(89, 100));
+        assert!(!meets_line_threshold(98, 100));
     }
 }


### PR DESCRIPTION
## Summary

- Raises the line-coverage threshold from 90% back to 99% in both the coverage driver binary and the CI workflow, now that Phase 3 has begun.
- Updates the unit test assertions to match the new 99% gate.

Closes #71

## Test plan

- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes (all 151 unit tests green)
- [x] CI `rust-coverage` workflow enforces 99% on next run