### PR TITLE
docs: add CLI build instructions to cli/README.md

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -68,40 +68,33 @@ cargo install --path .
 
 ## Development
 
-### Common Tasks
+The project defines cargo aliases in `.cargo/config.toml` for common tasks.
+All commands below should be run from the `cli/` directory.
 
-**Run unit tests:**
+### Testing
+
 ```bash
-cargo test --lib
+cargo test               # run all tests
+cargo test-unit          # unit tests only (--lib)
+cargo test-integration   # integration tests (cli, doctor, github, state, templates)
+cargo test-e2e           # end-to-end tests (--nocapture)
 ```
 
-**Run integration tests:**
-```bash
-cargo test --test '*'
-```
+### Code Quality
 
-**Run end-to-end tests:**
 ```bash
-cargo test --test e2e -- --nocapture
-```
-
-**Run all tests:**
-```bash
-cargo test
-```
-
-**Check code quality:**
-```bash
-cargo lint    # clippy with strict warnings
-cargo fmt-check  # format check
+cargo lint         # clippy with strict warnings (-D warnings)
+cargo fmt-check    # verify formatting (rustfmt --check)
 cargo build-check  # ensure all targets compile
 ```
 
-**Code coverage:**
+### Code Coverage
+
 ```bash
 cargo coverage
 ```
 
+This runs the `coverage-driver` binary (requires the `__dev_only` feature).
 Coverage reports are saved to `lcov.info`.
 
 ### Debugging


### PR DESCRIPTION
## Summary

- Rewrites the Development section of `cli/README.md` to reference the cargo aliases defined in `.cargo/config.toml` (`test-unit`, `test-integration`, `test-e2e`, `lint`, `fmt-check`, `build-check`, `coverage`) instead of raw cargo commands
- Fixes the integration test command to match the actual alias targets (was `cargo test --test '*'`, now `cargo test-integration`)
- Adds a note that the `coverage` command uses the `coverage-driver` binary with the `__dev_only` feature

Closes #87

## Test plan

- [x] Verify each alias in the README matches `.cargo/config.toml`
- [x] Confirm `cargo test-unit`, `cargo test-integration`, `cargo lint`, `cargo fmt-check`, `cargo build-check` run successfully from `cli/`