### PR TITLE
feat: parallel-aware Plan execution with strict merge ordering and integration handoff

### DIFF
--- a/.agents/commands/calypso-auto.md
+++ b/.agents/commands/calypso-auto.md
@@ -124,9 +124,34 @@ Do not stop merely because one pass finished. Stop only when:
 
 When blocked or ambiguous, report the diagnosis from `run.sh` back to the user.
 
+## Merge ordering and Plan position
+
+`merge-ready.sh` enforces Plan position at merge time. A PR can only merge when
+all preceding issues in the Plan are CLOSED. If a predecessor is still OPEN, the
+reason `plan-predecessor-not-merged` is returned and the merge is blocked.
+
+This means development can proceed on any eligible issue, but merges always
+happen in strict Plan order.
+
+## Integration handoff
+
+Before merging an issue, the `develop-issue` skill performs an integration
+handoff: it reads the next issue in Plan order (N+1) and, if that issue is OPEN,
+posts a comment on it summarizing files changed, new APIs, import path changes,
+and anything the next issue needs to know.
+
+## Parallel eligibility
+
+Use `.agents/scripts/auto/parallel-eligible.sh` to identify issues that could
+safely be developed alongside the currently selected issue. An issue is eligible
+for parallel development when all of its dependencies are already CLOSED.
+
+Issues marked with the `parallel_safe` annotation in the Plan (shown as a marker
+in the Plan body) were identified at replan time as having no open dependencies.
+
 ## Progress rules
 
-- Sequential execution is mandatory.
+- Sequential execution is mandatory for merging; parallel development is informational only.
 - Always prefer the smallest unblocker over speculative refactoring.
 - Clean up stale managed worktrees for merged PR branches before selection.
 - If a selected issue has no branch/worktree/PR yet, create them deterministically before research begins.

--- a/.agents/scripts/auto/merge-ready.sh
+++ b/.agents/scripts/auto/merge-ready.sh
@@ -37,6 +37,33 @@ if [[ "$(jq -r '.needs_rebase' <<<"$REBASE_JSON")" == "true" ]]; then
   reasons="$(jq -c '. + ["branch-behind-origin-main"]' <<<"$reasons")"
 fi
 
+# Plan position enforcement: all preceding Plan issues must be CLOSED
+linked_issue="$(jq -r '.linked_issue_number // empty' <<<"$PR_JSON")"
+if [[ -n "$linked_issue" ]]; then
+  TASKS_REPO="$(tasks_repo)"
+  PLAN_JSON_BODY="$(gh issue list --repo "$TASKS_REPO" --state open --json number,title --jq 'map(select(.title == "Plan")) | .[0].number // empty')"
+  if [[ -n "$PLAN_JSON_BODY" ]]; then
+    PLAN_BODY="$(gh issue view "$PLAN_JSON_BODY" --repo "$TASKS_REPO" --json body -q .body)"
+    mapfile -t plan_issues < <(printf '%s\n' "$PLAN_BODY" | extract_issue_refs)
+    predecessor_open=false
+    for plan_issue in "${plan_issues[@]}"; do
+      [[ -n "$plan_issue" ]] || continue
+      if [[ "$plan_issue" == "$linked_issue" ]]; then
+        break
+      fi
+      issue_state="$(gh issue view "$plan_issue" --repo "$TASKS_REPO" --json state -q .state)"
+      if [[ "$issue_state" != "CLOSED" ]]; then
+        predecessor_open=true
+        break
+      fi
+    done
+    if [[ "$predecessor_open" == "true" ]]; then
+      ready=false
+      reasons="$(jq -c '. + ["plan-predecessor-not-merged"]' <<<"$reasons")"
+    fi
+  fi
+fi
+
 jq -n \
   --argjson pr "$PR_JSON" \
   --argjson rebase "$REBASE_JSON" \

--- a/.agents/scripts/auto/parallel-eligible.sh
+++ b/.agents/scripts/auto/parallel-eligible.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=.agents/scripts/auto/common.sh
+source "$SCRIPT_DIR/common.sh"
+
+TASKS_REPO="$(tasks_repo)"
+PLAN_JSON="$(gh issue list --repo "$TASKS_REPO" --state open --json number,title --jq 'map(select(.title == "Plan")) | .[0]')"
+
+if [[ -z "$PLAN_JSON" || "$PLAN_JSON" == "null" ]]; then
+  jq -n '{eligible: [], reason: "plan-not-found"}'
+  exit 0
+fi
+
+PLAN_NUMBER="$(jq -r '.number' <<<"$PLAN_JSON")"
+PLAN_BODY="$(gh issue view "$PLAN_NUMBER" --repo "$TASKS_REPO" --json body -q .body)"
+
+mapfile -t plan_issues < <(printf '%s\n' "$PLAN_BODY" | extract_issue_refs)
+
+if [[ "${#plan_issues[@]}" -eq 0 ]]; then
+  jq -n '{eligible: [], reason: "no-plan-issues"}'
+  exit 0
+fi
+
+# Build state map: issue number -> state
+declare -A issue_states
+for issue_number in "${plan_issues[@]}"; do
+  [[ -n "$issue_number" ]] || continue
+  state="$(gh issue view "$issue_number" --repo "$TASKS_REPO" --json state -q .state)"
+  issue_states["$issue_number"]="$state"
+done
+
+# Find the currently selected (first OPEN) issue
+selected=""
+for issue_number in "${plan_issues[@]}"; do
+  [[ -n "$issue_number" ]] || continue
+  if [[ "${issue_states[$issue_number]}" == "OPEN" ]]; then
+    selected="$issue_number"
+    break
+  fi
+done
+
+if [[ -z "$selected" ]]; then
+  jq -n '{eligible: [], reason: "no-open-issues"}'
+  exit 0
+fi
+
+# For each issue after the selected one, check if all its dependencies are CLOSED
+eligible='[]'
+past_selected=false
+for issue_number in "${plan_issues[@]}"; do
+  [[ -n "$issue_number" ]] || continue
+
+  if [[ "$issue_number" == "$selected" ]]; then
+    past_selected=true
+    continue
+  fi
+
+  [[ "$past_selected" == "true" ]] || continue
+  [[ "${issue_states[$issue_number]}" == "OPEN" ]] || continue
+
+  # Get the issue's dependencies section
+  issue_body="$(gh issue view "$issue_number" --repo "$TASKS_REPO" --json body -q .body)"
+  dep_section="$(printf '%s\n' "$issue_body" | section_body "Dependencies")"
+  mapfile -t deps < <(printf '%s\n' "$dep_section" | extract_issue_refs)
+
+  all_deps_closed=true
+  for dep in "${deps[@]}"; do
+    [[ -n "$dep" ]] || continue
+    dep_state="${issue_states[$dep]:-}"
+    if [[ -z "$dep_state" ]]; then
+      dep_state="$(gh issue view "$dep" --repo "$TASKS_REPO" --json state -q .state)"
+    fi
+    if [[ "$dep_state" != "CLOSED" ]]; then
+      all_deps_closed=false
+      break
+    fi
+  done
+
+  if [[ "$all_deps_closed" == "true" ]]; then
+    issue_title="$(gh issue view "$issue_number" --repo "$TASKS_REPO" --json title -q .title)"
+    eligible="$(jq -c --argjson num "$issue_number" --arg title "$issue_title" \
+      '. + [{number: $num, title: $title}]' <<<"$eligible")"
+  fi
+done
+
+jq -n --argjson selected "$selected" --argjson eligible "$eligible" '{
+  selected: $selected,
+  eligible: $eligible
+}'

--- a/.agents/scripts/replan/apply-plan.sh
+++ b/.agents/scripts/replan/apply-plan.sh
@@ -20,7 +20,10 @@ body="$(jq -r '
     "",
     "> Last replanned: " + (now | todateiso8601 | split("T")[0]),
     "",
-    (.ordered_issues[] | "- #" + (.number|tostring) + " - " + .title + " [risk: " + (.risk|tostring) + "]")
+    (.ordered_issues[] |
+      "- #" + (.number|tostring) + " - " + .title + " [risk: " + (.risk|tostring) + "]"
+      + (if .parallel_safe == true then " ⊜" else "" end)
+    )
   ] | join("\n")
 ' "$PLAN_FILE")"
 

--- a/.agents/scripts/replan/validate-plan-json.sh
+++ b/.agents/scripts/replan/validate-plan-json.sh
@@ -31,9 +31,10 @@ if jq -e '
     or (.rationale == null)
     or ((.dependencies // []) | type != "array")
     or ((.dependents // []) | type != "array")
+    or (has("parallel_safe") and ((.parallel_safe | type) != "boolean"))
   )
 ' "$PLAN_FILE" >/dev/null; then
-  printf 'invalid plan json: ordered issue is missing required fields\n' >&2
+  printf 'invalid plan json: ordered issue is missing required fields or has invalid parallel_safe type\n' >&2
   exit 4
 fi
 

--- a/.agents/skills/develop-issue/SKILL.md
+++ b/.agents/skills/develop-issue/SKILL.md
@@ -61,8 +61,29 @@ Use these scripts as the source of truth:
 7. Update issue checklist items and stage when implementation evidence supports it.
 8. When `merge-ready.sh` says the PR is ready:
    - run `mark-pr-ready.sh`
+   - perform integration handoff (see below)
    - run `merge-pr.sh`
 9. Confirm the issue is closed.
+
+## Integration handoff
+
+Before merging, identify the next issue in Plan order (N+1). If it exists and is
+OPEN, post a comment on it that includes:
+
+- What files and modules changed in this PR
+- Any new or modified public APIs, type signatures, or module boundaries
+- Import path changes
+- Anything the N+1 issue scope would need to be aware of
+
+To find the next issue:
+
+1. Read the Plan tracking issue from the tasks repo.
+2. Extract the ordered issue numbers.
+3. Find the current issue's position.
+4. If there is a subsequent issue, fetch its state.
+5. If it is OPEN, post the handoff comment.
+
+Skip the handoff if there is no next issue or the next issue is already CLOSED.
 
 ## Stop only when
 

--- a/.agents/skills/replan-evaluate/SKILL.md
+++ b/.agents/skills/replan-evaluate/SKILL.md
@@ -27,7 +27,6 @@ Input should come from the deterministic replan scripts, especially:
 
 ## Must not do
 
-- Do not plan parallel work.
 - Do not emit phase, batch, or step metadata for issue titles or issue bodies.
 - Do not invent issue facts not grounded in the provided payload.
 - Do not emit free-form markdown as the primary output.
@@ -46,10 +45,22 @@ Emit JSON with this shape:
       "risk": 4,
       "rationale": "Cross-cutting CLI architecture removal touches many commands.",
       "dependencies": [],
-      "dependents": [201]
+      "dependents": [201],
+      "parallel_safe": true
     }
   ]
 }
 ```
 
 `ordered_issues` must be a strict total order with no parallel groups.
+
+### `parallel_safe` field
+
+Each issue must include a `parallel_safe` boolean. An issue is `parallel_safe: true`
+when its `dependencies` array is empty or contains only issues that are already
+CLOSED at replan time. Issues whose dependencies include any OPEN issue that
+appears earlier in the ordering are `parallel_safe: false`.
+
+This annotation is informational only. Merge ordering still follows the strict
+total order. The annotation tells tooling which issues could be safely developed
+concurrently without merge conflicts or integration risk.


### PR DESCRIPTION
Closes #204

## Summary

- Add Plan position enforcement to `merge-ready.sh` — a PR can only merge if all preceding Plan issues are closed
- Add integration handoff step to `develop-issue` skill — before merging issue N, post integration notes on issue N+1
- Create `parallel-eligible.sh` script to identify issues safe for concurrent development
- Update `replan-evaluate` skill to emit `parallel_safe` annotations on each issue
- Update `validate-plan-json.sh` and `apply-plan.sh` to support the new field
- Document parallel-aware execution in `calypso-auto.md`

## Key decisions

- Merge gating is deterministic (bash/jq), not LLM-driven — `merge-ready.sh` reads the Plan and checks predecessor closure
- `parallel_safe` is informational only — merge order is still strictly sequential per Plan
- Integration handoff is an LLM skill instruction, not a script — the agent reads N+1's scope and posts a comment

## Test plan

- [x] All existing CI checks pass (no Rust changes)
- [x] `merge-ready.sh` includes `plan-predecessor-not-merged` check
- [x] `parallel-eligible.sh` is executable and follows script conventions
- [x] Skill and command docs updated